### PR TITLE
Handle RTTI accordingly to how LLVM was built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ file(GLOB SRC_FILES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/sources/*.cpp)
 
 #TODO: use target_source
 add_executable(hyde   ${EMITTER_FILES} ${MATCHER_FILES} ${SRC_FILES})
+if (NOT LLVM_ENABLE_RTTI)
+    target_compile_options (hyde PRIVATE -fno-rtti)
+endif()
 
 
 target_include_directories(hyde PUBLIC ${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
As per commit title.
If LLVM was built without RTTI, hyde build fails at link time unless it's compiled with "-fno-rtti".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adobe/hyde/12)
<!-- Reviewable:end -->
