### PR TITLE
Fixing Ubuntu Version to match LLVM-7 dependencies. Currently tested on cosmic/bionic with llvm-7

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
         - `brew install boost`
         - `brew install ninja` (optional)
 ## LINUX
-note only tested on ubuntu bionic so far
+note only tested on ubuntu cosmic so far
 
 - Apt
     - `sudo apt-get install libboost-system-dev libboost-filesystem-dev`


### PR DESCRIPTION
The Requirements notes mention version 7 of the LLVM toolchain as dependencies. The Bionic release's llvm versions are pinned to LLVM 6