### PR TITLE
[Dont merge] This brings linux support into hyde

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,10 @@ target_include_directories(hyde PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(hyde SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 target_include_directories(hyde SYSTEM PUBLIC ${CLANG_INCLUDE_DIRS})
 target_include_directories(hyde SYSTEM PUBLIC ${LLVM_INCLUDE_DIRS})
-target_include_directories(hyde SYSTEM PUBLIC ${YAML_CPP_INCLUDE_DIR})
+#this gets a little messy with gcc so it can't be a system include :(
+#you end up with a "can't find stdlib.h" error if it is
+target_include_directories(hyde PUBLIC ${YAML_CPP_INCLUDE_DIR})
+
 
 target_compile_options(hyde PUBLIC -Wall  -Werror)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,12 +80,15 @@ target_compile_definitions(hyde PRIVATE
  CLANG_RESOURCE_DIR="${CLANG_RESOURCE_DIR}"
 )
 
-target_include_directories(hyde PUBLIC ${Boost_INCLUDE_DIRS})
-target_include_directories(hyde PUBLIC ${CLANG_INCLUDE_DIRS})
+#our headers
 target_include_directories(hyde PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(hyde PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_include_directories(hyde PUBLIC ${LLVM_INCLUDE_DIRS})
-target_include_directories(hyde PUBLIC ${YAML_CPP_INCLUDE_DIR})
+
+#3rd party
+target_include_directories(hyde SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
+target_include_directories(hyde SYSTEM PUBLIC ${CLANG_INCLUDE_DIRS})
+target_include_directories(hyde SYSTEM PUBLIC ${LLVM_INCLUDE_DIRS})
+target_include_directories(hyde SYSTEM PUBLIC ${YAML_CPP_INCLUDE_DIR})
 
 target_compile_options(hyde PUBLIC -Wall  -Werror)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,11 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Change these if you have a different location.
-set(BOOST_DIR /usr/local/Cellar/boost/1.67.0_1/)
-set(Clang_DIR /usr/local/Cellar/llvm/7.0.0/lib/cmake/clang/)
-set(LLVM_DIR /usr/local/Cellar/llvm/7.0.0/lib/cmake/llvm/)
-set(YAML_CPP_DIR /usr/local/Cellar/yaml-cpp/0.6.2/lib/cmake/yaml-cpp/)
+
+if(APPLE)
+    set(Clang_DIR /usr/local/Cellar/llvm/7.0.0/lib/cmake/clang/)
+    set(LLVM_DIR /usr/local/Cellar/llvm/7.0.0/lib/cmake/llvm/)
+endif()
 
 find_package(Clang REQUIRED clangTooling libClang clangASTMatchers)
 find_package(Clang REQUIRED CONFIG)
@@ -35,16 +35,50 @@ add_definitions(${YAML_CPP_DEFINITIONS})
 add_definitions(${Boost_LIB_DIAGNOSTIC_DEFINITIONS})
 
 
+#lets get the clang resource dir so we can set inside hyde
+if(DEFINED USE_APPLE_TOOLCHAIN)
+    execute_process(COMMAND "xcode-select" -p
+        RESULT_VARIABLE XCODE_SELECT_RESULT
+        OUTPUT_VARIABLE XCODE_SELECT
+        ERROR_VARIABLE  XCODE_SELECT_ERROR
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if(XCODE_SELECT_RESULT)
+        message(FATAL_ERROR "USE_APPLE_TOOLCHAIN was set but can not invoke xcode-select -p")
+        message(FATAL_ERROR ${XCODE_SELECT_ERROR})
+    endif()
+
+    set (CLANG_BIN ${XCODE_SELECT}/usr/bin/clang++)
+else()
+    set (CLANG_BIN ${CLANG_INSTALL_PREFIX}/bin/clang++)
+endif()
+
+execute_process(COMMAND ${CLANG_BIN} -print-resource-dir
+    RESULT_VARIABLE CLANG_RESOURCE_DIR_RESULT
+    OUTPUT_VARIABLE CLANG_RESOURCE_DIR
+    ERROR_VARIABLE  CLANG_RESOURCE_DIR_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if(CLANG_RESOURCE_DIR_RESULT)
+    message(FATAL_ERROR "Could not locate the resource dir for clang we are going to link against")
+    message(FATAL_ERROR ${CLANG_RESOURCE_DIR_ERROR})
+endif()
+
+message(STATUS "Using the following resource dir for clang: ${CLANG_RESOURCE_DIR}")
+
 file(GLOB EMITTER_FILES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/emitters/*.cpp)
 file(GLOB MATCHER_FILES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/matchers/*.cpp)
 file(GLOB SRC_FILES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/sources/*.cpp)
 
 #TODO: use target_source
-add_executable(hyde   ${EMITTER_FILES} ${MATCHER_FILES} ${SRC_FILES})
+add_executable(hyde  ${EMITTER_FILES} ${MATCHER_FILES} ${SRC_FILES})
 if (NOT LLVM_ENABLE_RTTI)
     target_compile_options (hyde PRIVATE -fno-rtti)
 endif()
 
+target_compile_definitions(hyde PRIVATE
+ CLANG_RESOURCE_DIR="${CLANG_RESOURCE_DIR}"
+)
 
 target_include_directories(hyde PUBLIC ${Boost_INCLUDE_DIRS})
 target_include_directories(hyde PUBLIC ${CLANG_INCLUDE_DIRS})
@@ -52,6 +86,8 @@ target_include_directories(hyde PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(hyde PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(hyde PUBLIC ${LLVM_INCLUDE_DIRS})
 target_include_directories(hyde PUBLIC ${YAML_CPP_INCLUDE_DIR})
+
+target_compile_options(hyde PUBLIC -Wall  -Werror)
 
 target_link_libraries(hyde
                       ${YAML_CPP_LIBRARIES}

--- a/emitters/yaml_base_emitter.cpp
+++ b/emitters/yaml_base_emitter.cpp
@@ -645,7 +645,7 @@ bool yaml_base_emitter::reconcile(json expected,
         // stir-crazy (it's a special token for the tool), so we remove them.
         static const std::string needle = "...";
         std::string p_str = path.string();
-        auto pos = 0;
+        std::size_t pos = 0;
         auto found = false;
         while (true) {
             pos = p_str.find(needle, pos);

--- a/emitters/yaml_library_emitter.cpp
+++ b/emitters/yaml_library_emitter.cpp
@@ -34,7 +34,7 @@ bool yaml_library_emitter::do_merge(const std::string& filepath,
 
 /**************************************************************************************************/
 
-bool yaml_library_emitter::emit(const json& j) {
+bool yaml_library_emitter::emit(const json&) {
     json node = base_emitter_node("library", "API Documentation", "library");
     node["library-type"] = "library";
 

--- a/generate_test_files.sh
+++ b/generate_test_files.sh
@@ -1,12 +1,33 @@
 #!/bin/bash
 
+#very simple for now, look in common locations
+find_hyde() {
+    BUILD_DIR=$1
+    if [ -f $BUILD_DIR/hyde ]
+    then
+        echo $BUILD_DIR/hyde
+        return 0
+    fi
+    if [ -f $BUILD_DIR/Debug/hyde ]
+    then
+        echo $BUILD_DIR/Debug/hyde
+        return 0
+    fi
+    if [ -f $BUILD_DIR/Release/hyde ]
+    then
+        echo $BUILD_DIR/Release/hyde
+        return 0
+    fi
+    return 1
+}   
+
 EXE_DIR=$(dirname "$0")
 
 pushd ${EXE_DIR} > /dev/null
 
 CUR_DUR=$(pwd)
+HYDE_PATH=`find_hyde "${CUR_DUR}/build"`
 
-HYDE_PATH=${CUR_DUR}/build/Debug/hyde # This assumes a binary built with Xcode.
 HYDE_SRC_ROOT=${CUR_DUR}
 HYDE_DST_ROOT=${CUR_DUR}/test_site/libraries
 

--- a/matchers/utilities.hpp
+++ b/matchers/utilities.hpp
@@ -63,6 +63,7 @@ inline std::string to_string(clang::AccessSpecifier access) {
         case clang::AccessSpecifier::AS_none:
             return "none";
     }
+    return "none";
 }
 
 /**************************************************************************************************/

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -121,9 +121,14 @@ static cl::opt<ToolDiagnostic> ToolDiagnostic(
 static cl::opt<std::string> YamlDstDir("hyde-yaml-dir",
                                        cl::desc("Root directory for YAML validation / update"),
                                        cl::cat(MyToolCategory));
-static cl::opt<std::string> YamlSrcDir(
+static cl::opt<std::string> ArgumentResourceDir(
     "hyde-src-root",
     cl::desc("The root path to the header file(s) being analyzed"),
+    cl::cat(MyToolCategory));
+    
+static cl::opt<std::string> YamlSrcDir(
+    "resource-dir",
+    cl::desc("The resource dir(see clang resource dir) for hyde to use."),
     cl::cat(MyToolCategory));
 
 static cl::extrahelp HydeHelp(
@@ -149,38 +154,6 @@ static cl::extrahelp HydeHelp(
     "file in your project. The flags sent to Clang should be a in a top-level\n"
     "array under the `clang_flags` key.\n"
     "\n");
-
-/**************************************************************************************************/
-
-boost::filesystem::path clang_path(boost::filesystem::path xcode_path) {
-    boost::filesystem::path root_clang_path =
-        xcode_path / "Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/";
-    boost::filesystem::path last_directory;
-
-    for (const auto& entry :
-         boost::make_iterator_range(boost::filesystem::directory_iterator(root_clang_path), {})) {
-        if (is_directory(entry)) {
-            last_directory = entry;
-        }
-    }
-
-    if (!exists(last_directory)) throw std::runtime_error("could not derive clang directory");
-
-    return last_directory / "include";
-}
-
-/**************************************************************************************************/
-
-boost::filesystem::path get_xcode_path() {
-    // This routine gets us to the "/path/to/Xcode.app/Contents/Developer" folder
-    std::string clang_details = exec("clang++ --version");
-    // This assumes "InstalledDir:" is the last flag in the lineup.
-    const std::string needle("InstalledDir: ");
-    auto installed_dir_pos = clang_details.find(needle);
-    boost::filesystem::path result =
-        clang_details.substr(installed_dir_pos + needle.size(), std::string::npos);
-    return canonical(result / ".." / ".." / ".." / "..");
-}
 
 /**************************************************************************************************/
 
@@ -328,9 +301,13 @@ int main(int argc, const char** argv) try {
     }
 
     //this may not work on windows, need to investigate using strings
-    const boost::filesystem::path resource_dir{CLANG_RESOURCE_DIR};
+<<<<<<< HEAD
+=======
+    boost::filesystem::path resource_dir{CLANG_RESOURCE_DIR};
 
 
+    CommonOptionsParser OptionsParser(argc, argv, MyToolCategory);
+>>>>>>> updating our script to locate hyde in known locations.
     auto sourcePaths = make_absolute(OptionsParser.getSourcePathList());
     ClangTool Tool(OptionsParser.getCompilations(), sourcePaths);
     MatchFinder Finder;
@@ -353,23 +330,14 @@ int main(int argc, const char** argv) try {
     hyde::TypedefInfo typedef_matcher(sourcePaths, ToolAccessFilter);
     Finder.addMatcher(hyde::TypedefInfo::GetMatcher(), &typedef_matcher);
 
-    // Get the current Xcode toolchain and add its include directories to the tool.
-   // const boost::filesystem::path xcode_path = get_xcode_path();
-
-    // Order matters here. The first include path will be looked up first, so should
-    // be the highest priority path.
-   // boost::filesystem::path include_directories[] = {
-    ///    clang_path(xcode_path),
-      //  "/Library/Developer/CommandLineTools/usr/include/c++/v1",
-      //  xcode_path / "/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/",
-   // };
-
-    
     clang::tooling::CommandLineArguments  arguments;
-    std::string resouree_arg("-resource-dir=");
-    resouree_arg += resource_dir.string();
+    if (!ArgumentResourceDir.empty())
+        resource_dir = boost::filesystem::path{ArgumentResourceDir};
+
+    std::string resource_arg("-resource-dir=");
+    resource_arg += resource_dir.string();
     arguments.emplace_back("-DADOBE_TOOL_HYDE=1");
-    arguments.emplace_back(resouree_arg);
+    arguments.emplace_back(resource_arg);
     Tool.appendArgumentsAdjuster(getInsertArgumentAdjuster(arguments, clang::tooling::ArgumentInsertPosition::END));
 
     if (Tool.run(newFrontendActionFactory(&Finder).get()))

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -300,14 +300,7 @@ int main(int argc, const char** argv) try {
         }
     }
 
-    //this may not work on windows, need to investigate using strings
-<<<<<<< HEAD
-=======
-    boost::filesystem::path resource_dir{CLANG_RESOURCE_DIR};
-
-
     CommonOptionsParser OptionsParser(argc, argv, MyToolCategory);
->>>>>>> updating our script to locate hyde in known locations.
     auto sourcePaths = make_absolute(OptionsParser.getSourcePathList());
     ClangTool Tool(OptionsParser.getCompilations(), sourcePaths);
     MatchFinder Finder;
@@ -331,14 +324,16 @@ int main(int argc, const char** argv) try {
     Finder.addMatcher(hyde::TypedefInfo::GetMatcher(), &typedef_matcher);
 
     clang::tooling::CommandLineArguments  arguments;
+    
+    boost::filesystem::path resource_dir{CLANG_RESOURCE_DIR};
     if (!ArgumentResourceDir.empty()) {
         resource_dir = boost::filesystem::path{ArgumentResourceDir};
     }
-
     std::string resource_arg("-resource-dir=");
     resource_arg += resource_dir.string();
     arguments.emplace_back("-DADOBE_TOOL_HYDE=1");
     arguments.emplace_back(resource_arg);
+    
     Tool.appendArgumentsAdjuster(getInsertArgumentAdjuster(arguments, clang::tooling::ArgumentInsertPosition::END));
 
     if (Tool.run(newFrontendActionFactory(&Finder).get()))

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -121,12 +121,12 @@ static cl::opt<ToolDiagnostic> ToolDiagnostic(
 static cl::opt<std::string> YamlDstDir("hyde-yaml-dir",
                                        cl::desc("Root directory for YAML validation / update"),
                                        cl::cat(MyToolCategory));
-static cl::opt<std::string> ArgumentResourceDir(
+static cl::opt<std::string> YamlSrcDir(
     "hyde-src-root",
     cl::desc("The root path to the header file(s) being analyzed"),
     cl::cat(MyToolCategory));
     
-static cl::opt<std::string> YamlSrcDir(
+static cl::opt<std::string> ArgumentResourceDir(
     "resource-dir",
     cl::desc("The resource dir(see clang resource dir) for hyde to use."),
     cl::cat(MyToolCategory));
@@ -331,8 +331,9 @@ int main(int argc, const char** argv) try {
     Finder.addMatcher(hyde::TypedefInfo::GetMatcher(), &typedef_matcher);
 
     clang::tooling::CommandLineArguments  arguments;
-    if (!ArgumentResourceDir.empty())
+    if (!ArgumentResourceDir.empty()) {
         resource_dir = boost::filesystem::path{ArgumentResourceDir};
+    }
 
     std::string resource_arg("-resource-dir=");
     resource_arg += resource_dir.string();

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -125,7 +125,7 @@ static cl::opt<std::string> YamlSrcDir(
     "hyde-src-root",
     cl::desc("The root path to the header file(s) being analyzed"),
     cl::cat(MyToolCategory));
-    
+
 static cl::opt<std::string> ArgumentResourceDir(
     "resource-dir",
     cl::desc("The resource dir(see clang resource dir) for hyde to use."),
@@ -239,8 +239,7 @@ std::vector<std::string> integrate_hyde_config(int argc, const char** argv) {
     std::tie(config_dir, config) =
         load_hyde_config(cli_hyde_flags.empty() ? "" : cli_hyde_flags.back());
 
-    if (exists(config_dir))
-        current_path(config_dir);
+    if (exists(config_dir)) current_path(config_dir);
 
     if (config.count("clang_flags")) {
         for (const auto& clang_flag : config["clang_flags"]) {
@@ -300,7 +299,6 @@ int main(int argc, const char** argv) try {
         }
     }
 
-    CommonOptionsParser OptionsParser(argc, argv, MyToolCategory);
     auto sourcePaths = make_absolute(OptionsParser.getSourcePathList());
     ClangTool Tool(OptionsParser.getCompilations(), sourcePaths);
     MatchFinder Finder;
@@ -323,8 +321,8 @@ int main(int argc, const char** argv) try {
     hyde::TypedefInfo typedef_matcher(sourcePaths, ToolAccessFilter);
     Finder.addMatcher(hyde::TypedefInfo::GetMatcher(), &typedef_matcher);
 
-    clang::tooling::CommandLineArguments  arguments;
-    
+    clang::tooling::CommandLineArguments arguments;
+
     boost::filesystem::path resource_dir{CLANG_RESOURCE_DIR};
     if (!ArgumentResourceDir.empty()) {
         resource_dir = boost::filesystem::path{ArgumentResourceDir};
@@ -333,8 +331,9 @@ int main(int argc, const char** argv) try {
     resource_arg += resource_dir.string();
     arguments.emplace_back("-DADOBE_TOOL_HYDE=1");
     arguments.emplace_back(resource_arg);
-    
-    Tool.appendArgumentsAdjuster(getInsertArgumentAdjuster(arguments, clang::tooling::ArgumentInsertPosition::END));
+
+    Tool.appendArgumentsAdjuster(
+        getInsertArgumentAdjuster(arguments, clang::tooling::ArgumentInsertPosition::END));
 
     if (Tool.run(newFrontendActionFactory(&Finder).get()))
         throw std::runtime_error("compilation failed.");


### PR DESCRIPTION
This is the fix for  #25. Also bumps up the warning/errors to wall and treat warnings as errors.

The script is now a little bit better at locating hyde inside the build directory. 