### PR TITLE
Path autodetection

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ There are several modes under which the tool can run:
 - `-hyde-src-root = <path>` - The root path to the header file(s) being analyzed. Affects `defined-in-file` output values by taking out the root path.
 - `-hyde-yaml-dir = <path>` - Root directory for YAML validation / update. Required for either hyde-validate or hyde-update modes.
 
+- `use-system-clang` - Autodetect and use necessary resource directories and include paths
+
 This tool parses the passed header using Clang. To pass arguments to the compiler (e.g., include directories), append them after the `--` token on the command line. For example:
 
-    hyde input_file.hpp -hyde-json -- -x c++ -I/path/to/includes
+    hyde input_file.hpp -hyde-json -use-system-clang -- -x c++ -I/path/to/includes
 
 Alternatively, if you have a compilation database and would like to pass that instead of command-line compiler arguments, you can pass that with `-p`.
 
@@ -60,10 +62,10 @@ While compiling the source file, the non-function macro `ADOBE_TOOL_HYDE` is def
 # Examples:
 
 To output JSON:
-```./hyde ../test_files/classes.cpp --```
+```./hyde -use-system-clang ../test_files/classes.cpp --```
 
 To validate pre-existing YAML:
-```./hyde ../test_files/classes.cpp -hyde-yaml-dir=/path/to/output -hyde-validate```
+```./hyde -use-system-clang -hyde-yaml-dir=/path/to/output -hyde-validate ../test_files/classes.cpp```
 
 To output updated YAML:
-```./hyde ../test_files/classes.cpp -hyde-yaml-dir=/path/to/output -hyde-update```
+```./hyde -use-system-clang -hyde-yaml-dir=/path/to/output -hyde-update ../test_files/classes.cpp```

--- a/include/autodetect.hpp
+++ b/include/autodetect.hpp
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 Adobe
+All Rights Reserved.
+
+NOTICE: Adobe permits you to use, modify, and distribute this file in
+accordance with the terms of the Adobe license agreement accompanying
+it. If you have received this file from a source other than Adobe,
+then your use, modification, or distribution of it requires the prior
+written permission of Adobe. 
+*/
+
+#pragma once
+
+// stdc++
+#include <string>
+#include <vector>
+
+// application
+#include "config.hpp"
+#include "filesystem.hpp"
+
+/**************************************************************************************************/
+
+namespace hyde {
+
+/**************************************************************************************************/
+
+std::vector<filesystem::path> autodetect_toolchain_paths();
+
+filesystem::path autodetect_resource_directory();
+
+#if HYDE_PLATFORM(APPLE)
+filesystem::path autodetect_sysroot_directory();
+#endif // HYDE_PLATFORM(APPLE)
+
+/**************************************************************************************************/
+
+} // namespace hyde
+
+/**************************************************************************************************/

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -1,0 +1,32 @@
+/*
+Copyright 2018 Adobe
+All Rights Reserved.
+
+NOTICE: Adobe permits you to use, modify, and distribute this file in
+accordance with the terms of the Adobe license agreement accompanying
+it. If you have received this file from a source other than Adobe,
+then your use, modification, or distribution of it requires the prior
+written permission of Adobe. 
+*/
+
+#pragma once
+
+/**************************************************************************************************/
+
+#define HYDE_PRIVATE_STRING_XSMASH(X, Y) X##Y
+#define HYDE_PRIVATE_STRING_SMASH(X, Y) HYDE_PRIVATE_STRING_XSMASH(X, Y)()
+
+#define HYDE_PLATFORM_PRIVATE_APPLE() 0
+#define HYDE_PLATFORM_PRIVATE_MICROSOFT() 0
+
+#define HYDE_PLATFORM(X) HYDE_PRIVATE_STRING_SMASH(HYDE_PLATFORM_PRIVATE_, X)
+
+#if defined(__APPLE__)
+    #undef HYDE_PLATFORM_PRIVATE_APPLE
+    #define HYDE_PLATFORM_PRIVATE_APPLE() 1
+#elif defined(_MSC_VER)
+    #undef HYDE_PLATFORM_PRIVATE_MICROSOFT
+    #define HYDE_PLATFORM_PRIVATE_MICROSOFT() 1
+#endif
+
+/**************************************************************************************************/

--- a/include/filesystem.hpp
+++ b/include/filesystem.hpp
@@ -1,0 +1,80 @@
+/*
+Copyright 2018 Adobe
+All Rights Reserved.
+
+NOTICE: Adobe permits you to use, modify, and distribute this file in
+accordance with the terms of the Adobe license agreement accompanying
+it. If you have received this file from a source other than Adobe,
+then your use, modification, or distribution of it requires the prior
+written permission of Adobe.
+*/
+
+/**************************************************************************************************/
+
+#pragma once
+
+/**************************************************************************************************/
+
+#define HYDE_FILESYSTEM_PRIVATE_STD() 0
+#define HYDE_FILESYSTEM_PRIVATE_STD_EXPERIMENTAL() 1
+#define HYDE_FILESYSTEM_PRIVATE_BOOST() 2
+
+/**************************************************************************************************/
+
+#if defined(STLAB_FORCE_BOOST_FILESYSTEM)
+    #define HYDE_FILESYSTEM_PRIVATE_SELECTION() HYDE_FILESYSTEM_PRIVATE_BOOST()
+#elif defined(__has_include) // Check if __has_include is present
+    #if __has_include(<filesystem>)
+        #include <filesystem>
+        #define HYDE_FILESYSTEM_PRIVATE_SELECTION() HYDE_FILESYSTEM_PRIVATE_STD()
+    #elif __has_include(<experimental/filesystem>)
+        #include <experimental/filesystem>
+        #define HYDE_FILESYSTEM_PRIVATE_SELECTION() HYDE_FILESYSTEM_PRIVATE_STD_EXPERIMENTAL()
+    #else
+        #define HYDE_FILESYSTEM_PRIVATE_SELECTION() HYDE_FILESYSTEM_PRIVATE_BOOST()
+    #endif
+#else
+    #define HYDE_FILESYSTEM_PRIVATE_SELECTION() HYDE_FILESYSTEM_PRIVATE_BOOST()
+#endif
+
+#define HYDE_FILESYSTEM(X) (HYDE_FILESYSTEM_PRIVATE_SELECTION() == HYDE_FILESYSTEM_PRIVATE_##X())
+
+/**************************************************************************************************/
+// The library can be used with boost::filesystem, std::experimental::filesystem or std::filesystem.
+// Without any additional define, it uses the versions from the standard, if it is available.
+//
+// If using of boost::filesystem shall be enforced, define STLAB_FORCE_BOOST_FILESYSTEM.
+
+#if HYDE_FILESYSTEM(BOOST)
+    #include <boost/filesystem.hpp>
+#endif
+
+/**************************************************************************************************/
+
+namespace hyde {
+
+/**************************************************************************************************/
+
+#if HYDE_FILESYSTEM(STD)
+
+    namespace filesystem = std::filesystem;
+
+#elif HYDE_FILESYSTEM(STD_EXPERIMENTAL)
+
+    namespace filesystem = std::experimental::filesystem;
+
+#elif HYDE_FILESYSTEM(BOOST)
+
+    namespace filesystem = boost::filesystem;
+
+#else
+
+    #error `filesystem` variant not specified
+
+#endif
+
+/**************************************************************************************************/
+
+} // namespace hyde
+
+/**************************************************************************************************/

--- a/sources/autodetect.cpp
+++ b/sources/autodetect.cpp
@@ -118,9 +118,9 @@ std::vector<filesystem::path> autodetect_include_paths() {
         lines.erase(paths_end, end(lines));
         lines.erase(begin(lines), next(paths_begin));
 
-        lines.erase(std::remove_if(begin(lines), end(lines), [](auto& s){
-            return s.find(".sdk/") != std::string::npos;
-        }), end(lines));
+        // lines.erase(std::remove_if(begin(lines), end(lines), [](auto& s){
+        //     return s.find(".sdk/") != std::string::npos;
+        // }), end(lines));
 
         // Some of the paths contain cruft at the end. Filter those out, too.
         std::transform(begin(lines), end(lines), std::back_inserter(result), [](auto s){

--- a/sources/autodetect.cpp
+++ b/sources/autodetect.cpp
@@ -1,0 +1,170 @@
+/*
+Copyright 2018 Adobe
+All Rights Reserved.
+
+NOTICE: Adobe permits you to use, modify, and distribute this file in
+accordance with the terms of the Adobe license agreement accompanying
+it. If you have received this file from a source other than Adobe,
+then your use, modification, or distribution of it requires the prior
+written permission of Adobe.
+*/
+
+// identity
+#include "autodetect.hpp"
+
+// stdc++
+#include <array>
+
+namespace filesystem = hyde::filesystem;
+
+/**************************************************************************************************/
+
+namespace {
+
+/**************************************************************************************************/
+
+std::vector<std::string> split(const char* p, std::size_t n) {
+    auto end = p + n;
+    std::vector<std::string> result;
+
+    while (p != end) {
+        while (p != end && *p == '\n') ++p; // eat newlines
+        auto begin = p;
+        while (p != end && *p != '\n') ++p; // eat non-newlines
+        result.emplace_back(begin, p);
+    }
+
+    return result;
+}
+
+/**************************************************************************************************/
+
+std::vector<std::string> file_slurp(boost::filesystem::path p) {
+    boost::filesystem::ifstream s(p);
+    s.seekg(0, std::ios::end);
+    std::size_t size = s.tellg();
+    auto buffer{std::make_unique<char[]>(size)};
+    s.seekg(0);
+    s.read(&buffer[0], size);
+    return split(buffer.get(), size);
+}
+
+/**************************************************************************************************/
+
+std::string trim_front(std::string s) {
+    std::size_t n(0);
+    std::size_t end(s.size());
+
+    while (n != end && (std::isspace(s[n]) || s[n] == '\n'))
+        ++n;
+
+    s.erase(0, n);
+
+    return s;
+}
+
+/**************************************************************************************************/
+
+std::string trim_back(std::string s) {
+    std::size_t start(s.size());
+
+    while (start != 0 && (std::isspace(s[start - 1]) || s[start - 1] == '\n'))
+        start--;
+
+    s.erase(start, std::string::npos);
+
+    return s;
+}
+
+/**************************************************************************************************/
+
+std::string chomp(std::string src) {
+    return trim_back(trim_front(std::move(src)));
+}
+
+/**************************************************************************************************/
+
+std::string exec(const char* cmd) {
+    std::array<char, 128> buffer;
+    std::string result;
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), pclose);
+    if (!pipe) {
+        throw std::runtime_error("popen() failed!");
+    }
+    while (fgets(buffer.data(), buffer.size(), pipe.get())) {
+        result += buffer.data();
+    }
+    return chomp(std::move(result));
+}
+
+/**************************************************************************************************/
+
+std::vector<filesystem::path> autodetect_include_paths() {
+    auto temp_dir = boost::filesystem::temp_directory_path();
+    auto temp_path = temp_dir / "hyde.tmp";
+    auto temp_path_str = temp_path.string();
+    auto command = "echo \"int main() { }\" | clang++ -x c++ -v - 2> " + temp_path_str;
+
+    std::system(command.c_str());
+
+    std::vector lines(file_slurp(temp_path));
+    static const std::string begin_string("#include <...> search starts here:");
+    static const std::string end_string("End of search list.");
+    auto paths_begin = std::find(begin(lines), end(lines), begin_string);
+    auto paths_end = std::find(begin(lines), end(lines), end_string);
+    std::vector<filesystem::path> result;
+
+    if (paths_begin != end(lines) && paths_end != end(lines)) {
+        lines.erase(paths_end, end(lines));
+        lines.erase(begin(lines), next(paths_begin));
+
+        lines.erase(std::remove_if(begin(lines), end(lines), [](auto& s){
+            return s.find(".sdk/") != std::string::npos;
+        }), end(lines));
+
+        // Some of the paths contain cruft at the end. Filter those out, too.
+        std::transform(begin(lines), end(lines), std::back_inserter(result), [](auto s){
+            static const std::string needle_k{" (framework directory)"};
+            auto needle_pos = s.find(needle_k);
+            if (needle_pos != std::string::npos) {
+                s.erase(needle_pos);
+            }
+            return filesystem::path(chomp(std::move(s)));
+        });
+    }
+
+    return result;
+}
+
+/**************************************************************************************************/
+
+} // namespace
+
+/**************************************************************************************************/
+
+namespace hyde {
+
+/**************************************************************************************************/
+
+std::vector<filesystem::path> autodetect_toolchain_paths() {
+    return autodetect_include_paths();
+}
+
+/**************************************************************************************************/
+
+boost::filesystem::path autodetect_resource_directory() {
+    return boost::filesystem::path{exec("clang++ -print-resource-dir")};
+}
+
+/**************************************************************************************************/
+#if HYDE_PLATFORM(APPLE)
+boost::filesystem::path autodetect_sysroot_directory() {
+    return boost::filesystem::path{exec("xcode-select -p")} /
+           "Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk";
+}
+#endif // HYDE_PLATFORM(APPLE)
+/**************************************************************************************************/
+
+} // namespace hyde
+
+/**************************************************************************************************/

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -294,7 +294,6 @@ int main(int argc, const char** argv) try {
         if (!is_directory(new_parent)) {
             new_parent = new_parent.parent_path();
         }
-        boost::filesystem::current_path(std::move(new_parent));
     }
 
     std::vector<std::string> args = integrate_hyde_config(argc, argv);

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -130,23 +130,33 @@ static cl::opt<std::string> ArgumentResourceDir(
 
 static cl::opt<bool> AutoResourceDirectory(
     "auto-resource-dir",
-    cl::desc("Autodetect clang's resource directory"),
+    cl::desc("Autodetect and use clang's resource directory"),
     cl::cat(MyToolCategory),
     cl::ValueDisallowed);
 
 static cl::opt<bool> AutoToolchainIncludes(
     "auto-toolchain-includes",
-    cl::desc("Autodetect and include the toolchain include paths"),
+    cl::desc("Autodetect and use the toolchain include paths"),
     cl::cat(MyToolCategory),
     cl::ValueDisallowed);
 
 #if HYDE_PLATFORM(APPLE)
 static cl::opt<bool> AutoSysrootDirectory(
     "auto-sysroot",
-    cl::desc("Autodetect and specify isysroot"),
+    cl::desc("Autodetect and use isysroot"),
     cl::cat(MyToolCategory),
     cl::ValueDisallowed);
 #endif
+
+static cl::opt<bool> UseSystemClang(
+    "use-system-clang",
+#if HYDE_PLATFORM(APPLE)
+    cl::desc("Synonym for both -auto-resource-dir and -auto-sysroot"),
+#else
+    cl::desc("Synonym for both -auto-resource-dir and -auto-toolchain-includes"),
+#endif
+    cl::cat(MyToolCategory),
+    cl::ValueDisallowed);
 
 static cl::list<std::string> NamespaceBlacklist(
     "namespace-blacklist",
@@ -328,6 +338,15 @@ int main(int argc, const char** argv) try {
                    [](const auto& arg) { return arg.c_str(); });
 
     CommonOptionsParser OptionsParser(new_argc, &new_argv[0], MyToolCategory);
+
+    if (UseSystemClang) {
+        AutoResourceDirectory = true;
+#if HYDE_PLATFORM(APPLE)
+        AutoSysrootDirectory = true;
+#else
+        AutoToolchainIncludes = true;
+#endif
+    }
 
     if (IsVerbose()) {
         std::cout << "INFO: Args:\n";


### PR DESCRIPTION
Adding a couple new flags to hyde that I hope will help make it easier for a new user to get up and running with the tool more quickly. Note that these shouldn't have an effect on the current default workflows of the tool - they only have an effect when explicitly specified:

- `hyde-very-verbose` - output the clang driver's verbose output
- `auto-resource-dir` - Derive the resource directory automatically
- `auto-sysroot` - Derive and specify isysroot
- `auto-toolchain-includes` - Derive and include the toolchain include paths
- `use-system-clang` - Combo of `auto-resource-dir` and `auto-sysroot` on the Mac, `auto-resource-dir` and `auto-toolchain-includes` elsewhere.