### PR TITLE
docs: Corrected some missed punctuation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
-4. See error
+4. See error.
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
@@ -21,15 +21,15 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+ - OS: [e.g. iOS].
+ - Browser [e.g. chrome, safari].
+ - Version [e.g. 22].
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+ - Device: [e.g. iPhone6].
+ - OS: [e.g. iOS8.1].
+ - Browser [e.g. stock browser, safari].
+ - Version [e.g. 22].
 
 **Additional context**
 Add any other context about the problem here.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,22 +14,22 @@ orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* Using welcoming and inclusive language.
+* Being respectful of differing viewpoints and experiences.
+* Gracefully accepting constructive criticism.
+* Focusing on what is best for the community.
+* Showing empathy towards other community members.
 
 Examples of unacceptable behavior by participants include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or
-advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
+advances.
+* Trolling, insulting/derogatory comments, and personal or political attacks.
+* Public or private harassment.
 * Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
+  address, without explicit permission.
 * Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+  professional setting.
 
 ## Our Responsibilities
 
@@ -68,7 +68,7 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+available at [http://contributor-covenant.org/version/1/4][version].
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -31,25 +31,25 @@ note only tested on ubuntu bionic so far
 
 # How to Build
 
-- clone this repo
+- Clone this repo.
 - `cd hyde`
 - `mkdir build`
 - `cd build`
-- `cmake .. -GNinja` (or `-GXcode`, etc.)
-- `ninja` (or whatever your IDE does)
+- `cmake .. -GNinja` (or `-GXcode`, etc).
+- `ninja` (or whatever your IDE does).
 
 # Parameters and Flags
 
 There are several modes under which the tool can run:
 
-- `-hyde-json` - (default) Output an analysis dump of the input file as JSON
-- `-hyde-validate` - Validate existing YAML documentation
-- `-hyde-update` - Write updated YAML documentation
+- `-hyde-json` - (default) Output an analysis dump of the input file as JSON.
+- `-hyde-validate` - Validate existing YAML documentation.
+- `-hyde-update` - Write updated YAML documentation.
 
 - `-hyde-src-root = <path>` - The root path to the header file(s) being analyzed. Affects `defined-in-file` output values by taking out the root path.
 - `-hyde-yaml-dir = <path>` - Root directory for YAML validation / update. Required for either hyde-validate or hyde-update modes.
 
-- `use-system-clang` - Autodetect and use necessary resource directories and include paths
+- `use-system-clang` - Autodetect and use necessary resource directories and include paths.
 
 This tool parses the passed header using Clang. To pass arguments to the compiler (e.g., include directories), append them after the `--` token on the command line. For example:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,6 +32,6 @@ layout: default
     {% endfor %}
   </ul>
 
-  <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
+  <p class="rss-subscribe">Subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
 
 </div>

--- a/generate_test_files.sh
+++ b/generate_test_files.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#very simple for now, look in common locations
+# very simple for now, look in common locations
 find_hyde() {
     BUILD_DIR=$1
     if [ -f $BUILD_DIR/hyde ]


### PR DESCRIPTION
Added missing punctuation and capitalisation to a couple of documents to neaten the structure.
The following files have been amended:
README.md (Added missing punctuation/capitalisation).
CODE_OF_CONDUCT.md (Added missing punctuation).
docs/index.html (Capitalised subscribe at the bottom of the document).
.github/ISSUE_TEMPLATE/bug_report.md (Added missing punctuation).
generate_test_files.sh (Added a space to the comment).

These changes break nothing and mearly neaten the structure of the files.