### PR TITLE
Updating various dependencies. 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/yaml-cpp"]
+	path = submodules/yaml-cpp
+	url = https://github.com/jbeder/yaml-cpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,16 +40,13 @@ endif()
 find_package(Clang REQUIRED clangTooling libClang clangASTMatchers)
 find_package(Clang REQUIRED CONFIG)
 find_package(LLVM REQUIRED CONFIG)
-find_package(YAML-CPP REQUIRED CONFIG)
 
 set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost COMPONENTS system filesystem REQUIRED)
 
 add_definitions(${Clang_DEFINITIONS})
 add_definitions(${LLVM_DEFINITIONS})
-add_definitions(${YAML_CPP_DEFINITIONS})
 add_definitions(${Boost_LIB_DIAGNOSTIC_DEFINITIONS})
-
 
 #lets get the clang resource dir so we can set inside hyde
 if(DEFINED USE_APPLE_TOOLCHAIN)
@@ -86,8 +83,10 @@ file(GLOB EMITTER_FILES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/emitters/*
 file(GLOB MATCHER_FILES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/matchers/*.cpp)
 file(GLOB SRC_FILES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/sources/*.cpp)
 
+file(GLOB YAML_CPP_SRC_FILES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/submodules/yaml-cpp/src/*.cpp)
+
 #TODO: use target_source
-add_executable(hyde  ${EMITTER_FILES} ${MATCHER_FILES} ${SRC_FILES})
+add_executable(hyde  ${EMITTER_FILES} ${MATCHER_FILES} ${SRC_FILES} ${YAML_CPP_SRC_FILES})
 if (NOT LLVM_ENABLE_RTTI)
     target_compile_options (hyde PRIVATE -fno-rtti)
 endif()
@@ -104,12 +103,11 @@ target_include_directories(hyde PUBLIC ${CLANG_INCLUDE_DIRS})
 target_include_directories(hyde PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(hyde PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(hyde PUBLIC ${LLVM_INCLUDE_DIRS})
-target_include_directories(hyde PUBLIC ${YAML_CPP_INCLUDE_DIR})
+target_include_directories(hyde PUBLIC ${PROJECT_SOURCE_DIR}/submodules/yaml-cpp/include/)
 
-target_compile_options(hyde PUBLIC -Wall  -Werror)
+target_compile_options(hyde PUBLIC -Wall  -Werror -DHYDE_FORCE_BOOST_FILESYSTEM=1)
 
 target_link_libraries(hyde
-                      ${YAML_CPP_LIBRARIES}
                       ${Boost_FILESYSTEM_LIBRARY}
                       ${Boost_SYSTEM_LIBRARY}
                       clangASTMatchers

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
    - Homebrew
         - `brew install cmake`
         - `brew install llvm`
-        - `brew install yaml-cpp --with-static-lib`
         - `brew install boost`
         - `brew install ninja` (optional)
 ## LINUX
@@ -26,13 +25,14 @@ note only tested on ubuntu bionic so far
 - Apt
     - `sudo apt-get install libboost-system-dev libboost-filesystem-dev`
     - `sudo apt-get install libyaml-cpp-dev`
-    - `sudo apt-get install libllvm7 llvm-7 llvm-7-dev`
-    - `sudo apt-get install clang-tools-7 libclang-common-7-dev clang-7 libclang-7-dev`
+    - `sudo apt-get install libllvm9 llvm-9 llvm-9-dev`
+    - `sudo apt-get install clang-tools-9 libclang-common-9-dev clang-9 libclang-9-dev`
 
 # How to Build
 
 - clone this repo
 - `cd hyde`
+- `git submodule update --init`
 - `mkdir build`
 - `cd build`
 - `cmake .. -GNinja` (or `-GXcode`, etc.)

--- a/include/filesystem.hpp
+++ b/include/filesystem.hpp
@@ -21,7 +21,7 @@ written permission of Adobe.
 
 /**************************************************************************************************/
 
-#if defined(STLAB_FORCE_BOOST_FILESYSTEM)
+#if defined(HYDE_FORCE_BOOST_FILESYSTEM)
     #define HYDE_FILESYSTEM_PRIVATE_SELECTION() HYDE_FILESYSTEM_PRIVATE_BOOST()
 #elif defined(__has_include) // Check if __has_include is present
     #if __has_include(<filesystem>)
@@ -43,7 +43,7 @@ written permission of Adobe.
 // The library can be used with boost::filesystem, std::experimental::filesystem or std::filesystem.
 // Without any additional define, it uses the versions from the standard, if it is available.
 //
-// If using of boost::filesystem shall be enforced, define STLAB_FORCE_BOOST_FILESYSTEM.
+// If using of boost::filesystem shall be enforced, define HYDE_FORCE_BOOST_FILESYSTEM.
 
 #if HYDE_FILESYSTEM(BOOST)
     #include <boost/filesystem.hpp>

--- a/matchers/utilities.cpp
+++ b/matchers/utilities.cpp
@@ -145,9 +145,11 @@ std::string GetSignature(const ASTContext* n,
     }
 
     if (auto ctor_decl = llvm::dyn_cast_or_null<CXXConstructorDecl>(function)) {
-        if (ctor_decl->isExplicitSpecified()) signature << "explicit ";
+        auto specifier = ctor_decl->getExplicitSpecifier();
+        if (specifier.isExplicit()) signature << "explicit ";
     } else if (auto conversion_decl = llvm::dyn_cast_or_null<CXXConversionDecl>(function)) {
-        if (conversion_decl->isExplicitSpecified()) signature << "explicit ";
+        auto specifier = conversion_decl->getExplicitSpecifier();
+        if (specifier.isExplicit()) signature << "explicit ";
     }
 
     if (!isa<CXXConstructorDecl>(function) && !isa<CXXDestructorDecl>(function) &&
@@ -439,7 +441,8 @@ boost::optional<json> DetailFunctionDecl(const hyde::processing_options& options
                 info["is_ctor"] = true;
 
                 if (auto ctor_decl = llvm::dyn_cast_or_null<CXXConstructorDecl>(method)) {
-                    if (ctor_decl->isExplicitSpecified()) info["explicit"] = true;
+                    auto specifier = ctor_decl->getExplicitSpecifier();
+                    if (specifier.isExplicit()) info["explicit"] = true;
                 }
             }
             if (is_dtor) info["is_dtor"] = true;
@@ -448,7 +451,8 @@ boost::optional<json> DetailFunctionDecl(const hyde::processing_options& options
         }
 
         if (auto conversion_decl = llvm::dyn_cast_or_null<CXXConversionDecl>(method)) {
-            if (conversion_decl->isExplicitSpecified()) info["explicit"] = true;
+            auto specifier = conversion_decl->getExplicitSpecifier();
+            if (specifier.isExplicit()) info["explicit"] = true;
         }
     }
 

--- a/sources/autodetect.cpp
+++ b/sources/autodetect.cpp
@@ -14,6 +14,7 @@ written permission of Adobe.
 
 // stdc++
 #include <array>
+#include <random>
 
 namespace filesystem = hyde::filesystem;
 
@@ -100,14 +101,16 @@ std::string exec(const char* cmd) {
 /**************************************************************************************************/
 
 std::vector<filesystem::path> autodetect_include_paths() {
+    // Add a random value here so two concurrent instances of hyde don't collide.
+    auto v = std::to_string(std::mt19937(std::random_device()())());
     auto temp_dir = boost::filesystem::temp_directory_path();
-    auto temp_path = temp_dir / "hyde.tmp";
-    auto temp_path_str = temp_path.string();
-    auto command = "echo \"int main() { }\" | clang++ -x c++ -v - 2> " + temp_path_str;
+    auto temp_out = (temp_dir / ("hyde_" + v + ".tmp")).string();
+    auto temp_a_out = (temp_dir / ("deleteme_" + v)).string();
+    auto command = "echo \"int main() { }\" | clang++ -x c++ -v -o " + temp_a_out + " - 2> " + temp_out;
 
     std::system(command.c_str());
 
-    std::vector lines(file_slurp(temp_path));
+    std::vector lines(file_slurp(temp_out));
     static const std::string begin_string("#include <...> search starts here:");
     static const std::string end_string("End of search list.");
     auto paths_begin = std::find(begin(lines), end(lines), begin_string);


### PR DESCRIPTION
- Updated to LLVM 9, and made changes to accommodate. This is required because LLVM 7 fails to build under Xcode 11.1.
- Also including yaml-cpp as a submodule dependency. There's a strange crash on some dev machines that appear to be from the Homebrew install of yaml-cpp. I am hoping including these sources and building them directly will improve things.