### PR TITLE
Make sure all elements get validated/updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ There are several modes under which the tool can run:
 - `-hyde-validate` - Validate existing YAML documentation
 - `-hyde-update` - Write updated YAML documentation
 
-- `-hyde-src-root = <path>` - The root path to the header file(s) being analyzed. Affects `defined-in-file` output values by taking out the root path.
+- `-hyde-src-root = <path>` - The root path to the header file(s) being analyzed. Affects `defined_in_file` output values by taking out the root path.
 - `-hyde-yaml-dir = <path>` - Root directory for YAML validation / update. Required for either hyde-validate or hyde-update modes.
 
 - `use-system-clang` - Autodetect and use necessary resource directories and include paths

--- a/docs/_includes/defined_in_header.html
+++ b/docs/_includes/defined_in_header.html
@@ -1,3 +1,3 @@
-{% if page.defined-in-file %}
-<div>Defined in <code>&lt;{{page.defined-in-file}}&gt;</code></div>
+{% if page.defined_in_file %}
+<div>Defined in <code>&lt;{{page.defined_in_file}}&gt;</code></div>
 {% endif %}

--- a/emitters/yaml_base_emitter.cpp
+++ b/emitters/yaml_base_emitter.cpp
@@ -780,6 +780,7 @@ bool yaml_base_emitter::check_object_array(const std::string& filepath,
             json merged;
             failure |= proc(filepath, have[have_index], expected_object, nodepath, merged);
             result_array.push_back(std::move(merged));
+            have_map.erase(have_found_iter);
         }
         ++index;
     }

--- a/emitters/yaml_base_emitter.cpp
+++ b/emitters/yaml_base_emitter.cpp
@@ -153,7 +153,7 @@ YAML::Node json_to_yaml_ordered(hyde::json j) {
     move_key("brief");
     move_key("tags");
     move_key("library-type");
-    move_key("defined-in-file");
+    move_key("defined_in_file");
     move_key("declaration");
     move_key("annotation");
 
@@ -262,7 +262,17 @@ bool yaml_base_emitter::check_scalar(const std::string& filepath,
     };
 
     if (!expected_node.count(key)) {
-        throw std::runtime_error("missing expected scalar?");
+        if (!have_node.count(key)) {
+            // Removed key not present in have. Do nothing, no error.
+            return false;
+        } else {
+            notify("value present for removed key", "value removed");
+            auto merged_iter = merged_node.find(key);
+            if (merged_iter != merged_node.end()) {
+                merged_node.erase(merged_iter);
+            }
+            return true;
+        }
     }
 
     const json& expected = expected_node[key];
@@ -325,17 +335,18 @@ bool yaml_base_emitter::check_scalar(const std::string& filepath,
     }
 
     // both have and expected are both scalar and are the same value
+    result = have;
     return false;
 }
 
 /**************************************************************************************************/
 
-bool yaml_base_emitter::check_scalar_array(const std::string& filepath,
-                                           const json& have_node,
-                                           const json& expected_node,
-                                           const std::string& nodepath,
-                                           json& merged_node,
-                                           const std::string& key) {
+bool yaml_base_emitter::check_ungenerated_scalar_array(const std::string& filepath,
+                                                       const json& have_node,
+                                                       const json& expected_node,
+                                                       const std::string& nodepath,
+                                                       json& merged_node,
+                                                       const std::string& key) {
     const auto notify = [&](const std::string& validate_message,
                             const std::string& update_message) {
         check_notify(filepath, nodepath, key, validate_message, update_message);
@@ -346,7 +357,17 @@ bool yaml_base_emitter::check_scalar_array(const std::string& filepath,
     };
 
     if (!expected_node.count(key)) {
-        throw std::runtime_error("missing expected node?");
+        if (!have_node.count(key)) {
+            // Removed key not present in have. Do nothing, no error.
+            return false;
+        } else {
+            notify("value present for removed key", "value removed");
+            auto merged_iter = merged_node.find(key);
+            if (merged_iter != merged_node.end()) {
+                merged_node.erase(merged_iter);
+            }
+            return true;
+        }
     }
 
     const json& expected = expected_node[key];
@@ -388,6 +409,7 @@ bool yaml_base_emitter::check_scalar_array(const std::string& filepath,
         }
 
         if (expected_scalar == tag_value_optional_k && have_scalar == tag_value_optional_k) {
+            result = have;
             return false;
         }
 
@@ -401,6 +423,7 @@ bool yaml_base_emitter::check_scalar_array(const std::string& filepath,
 
     if (!have.is_array()) {
         notify_fail("value not an array; expected an array of scalar values");
+        result = have;
         return true;
     }
 
@@ -418,6 +441,129 @@ bool yaml_base_emitter::check_scalar_array(const std::string& filepath,
             notify_fail("invalid value at index " + std::to_string(index));
         }
     }
+
+    return failure;
+}
+
+/**************************************************************************************************/
+
+bool yaml_base_emitter::check_scalar_array(const std::string& filepath,
+                                           const json& have_node,
+                                           const json& expected_node,
+                                           const std::string& nodepath,
+                                           json& merged_node,
+                                           const std::string& key) {
+    const auto notify = [&](const std::string& validate_message,
+                            const std::string& update_message) {
+        check_notify(filepath, nodepath, key, validate_message, update_message);
+    };
+
+    const auto notify_fail = [&](const std::string& message) {
+        check_notify(filepath, nodepath, key, message, message);
+    };
+
+    if (!expected_node.count(key)) {
+        if (!have_node.count(key)) {
+            // Removed key not present in have. Do nothing, no error.
+            return false;
+        } else {
+            notify("value present for removed key", "value removed");
+            return true;
+        }
+    }
+
+    const json& expected = expected_node[key];
+
+    if (!expected.is_array()) {
+        notify_fail("expected type mismatch");
+        throw std::runtime_error("Merge scalar array failure");
+    }
+
+    json& result = merged_node[key];
+
+    if (!have_node.count(key) || !have_node[key].is_array()) {
+        notify("value not an array", "non-array value replaced");
+        result = expected;
+        return true;
+    }
+
+    const json& have = have_node[key];
+
+    // How does one merge an array of scalars? The solution is to use scalar value
+    // as the "key", and treat the array like a dictionary. This does create the
+    // possibility that multiple objects will resolve to the same key, and/or the
+    // key value may not be a string, so we establish those requirements as function
+    // preconditions.
+    //
+    // As for the actual merge, we have a `have` array, and an `expected` array.
+    // The resulting merge will be built up in a resulting array, then moved
+    // into `result.`
+    //
+    // First we build up a sorted vector of key/position pairs of the `have`
+    // array. This will let us find elements in that array in log(N) time.
+    //
+    // Then we iterate the expected array from first to last. We pull out the
+    // expected key and search for it in the have array. If it is missing, copy
+    // the expected element into the result array, and move on. If it is found,
+    // make sure they are in the same index in both arrays, otherwise it's a
+    // validation error. The result array is then moved into the resulting json.
+    //
+    // If `have` has extraneous keys, they will be skipped during the iteration
+    // of `expected` and subsequently dropped.
+    //
+    // The entire merge process should be O(N log N) time, bounded on the sort
+    // of the have key vector. Thanks to Jared Wyles for the tip on how to solve
+    // this one.
+
+    std::vector<std::pair<std::string, std::size_t>> have_map;
+    std::size_t count{0};
+    bool failure{false};
+    for (const auto& have_element : have) {
+        const std::string& have_str = have_element;
+        have_map.push_back(std::make_pair(have_str, count++));
+    }
+
+    std::sort(have_map.begin(), have_map.end());
+
+    // Now go one by one through the expected list, and reorganize.
+    std::size_t index{0};
+    json result_array;
+    for (const auto& expected_element : expected) {
+        const std::string& expected_str = expected_element;
+        const auto have_found_iter =
+            std::lower_bound(have_map.begin(), have_map.end(), expected_str,
+                             [](const auto& a, const auto& b) { return a.first < b; });
+        bool have_found =
+            have_found_iter != have_map.end() && have_found_iter->first == expected_str;
+        std::string index_str(std::to_string(index));
+        if (!have_found) {
+            notify("missing required string at index " + index_str,
+                   "required string inserted at index " + index_str);
+            result_array.push_back(expected_str);
+            failure = true;
+        } else {
+            std::size_t have_index = have_found_iter->second;
+            if (have_index != index) {
+                std::string have_index_str(std::to_string(have_index));
+                notify("bad item location for item `" + expected_str + "`; have: " + have_index_str + ", expected: " + index_str,
+                       "moved item `" + expected_str + "` at index " + have_index_str + " to index " + index_str);
+                failure = true;
+            }
+            result_array.push_back(expected_str);
+        }
+        ++index;
+    }
+
+    if (have.size() != expected.size()) {
+        std::string have_size(std::to_string(have.size()));
+        std::string expected_size(std::to_string(expected.size()));
+        std::string message =
+            "sequence size mismatch; have " + have_size + ", expected " + expected_size;
+        notify(message, message + "; fixed");
+        failure = true;
+    }
+
+    result = std::move(result_array);
 
     return failure;
 }
@@ -442,8 +588,13 @@ bool yaml_base_emitter::check_object_array(const std::string& filepath,
     };
 
     if (!expected_node.count(key)) {
-        notify_fail("missing expected array");
-        throw std::runtime_error("Merge object array failure");
+        if (!have_node.count(key)) {
+            // Removed key not present in have. Do nothing, no error.
+            return false;
+        } else {
+            notify("value present for removed key", "value removed");
+            return true;
+        }
     }
 
     const json& expected = expected_node[key];
@@ -480,7 +631,7 @@ bool yaml_base_emitter::check_object_array(const std::string& filepath,
     // expected key and search for it in the have array. If it is missing, copy
     // the expected element into the result array, and move on. If it is found,
     // make sure they are in the same index in both arrays, otherwise it's a
-    // validation error. Once that is done, merge the two objects together will
+    // validation error. Once that is done, merge the two objects together with
     // the user callback. The merged result is then pushed onto the back of the
     // result array. The result array is then moved into the resulting json.
     //
@@ -532,8 +683,8 @@ bool yaml_base_emitter::check_object_array(const std::string& filepath,
             std::size_t have_index = have_found_iter->second;
             if (have_index != index) {
                 std::string have_index_str(std::to_string(have_index));
-                notify("bad item location; have: " + have_index_str + ", expected: " + index_str,
-                       "moved item at index " + have_index_str + " to index " + index_str);
+                notify("bad item location for key `" + expected_key + "`; have: " + have_index_str + ", expected: " + index_str,
+                       "moved item with key `" + expected_key + "` at index " + have_index_str + " to index " + index_str);
                 failure = true;
             }
             std::string nodepath = "['" + key + "'][" + index_str + "]";
@@ -573,7 +724,13 @@ bool yaml_base_emitter::check_map(const std::string& filepath,
     };
 
     if (!expected_node.count(key)) {
-        throw std::runtime_error("missing expected map?");
+        if (!have_node.count(key)) {
+            // Removed key not present in have. Do nothing, no error.
+            return false;
+        } else {
+            notify("value present for removed key", "value removed");
+            return true;
+        }
     }
 
     const json& expected = expected_node[key];
@@ -605,6 +762,8 @@ bool yaml_base_emitter::check_map(const std::string& filepath,
     keys.erase(std::unique(keys.begin(), keys.end()), keys.end());
 
     bool failure{false};
+    
+    result = have;
 
     for (const auto& subkey : keys) {
         std::string curnodepath = nodepath + "['" + subkey + "']";
@@ -631,17 +790,29 @@ std::pair<bool, json> yaml_base_emitter::merge(const std::string& filepath,
                                                const json& have,
                                                const json& expected) {
     bool failure{false};
-    json merged = have; // we can probably get rid of `have` in the check
-                        // routines; I don't think we can keep it from being an
-                        // out-arg, though, because we need to preserve the
-                        // values in `have` that are not managed by the
-                        // `expected` schema.
+    
+    static const auto root_key = "<root>";
+    json merged_root = hyde::json::object();
+    json have_root = hyde::json::object();
+    have_root[root_key] = have;
+    json expected_root = hyde::json::object();
+    expected_root[root_key] = expected;
+    failure |= check_map(filepath, have_root, expected_root, "", merged_root, root_key,
+        [](const std::string& filepath, const json& have, const json& expected,
+            const std::string& nodepath, json& out_merged) { return false; });
+    json& merged = merged_root[root_key];
+    
+    // we can probably get rid of `have` in the check
+    // routines; I don't think we can keep it from being an
+    // out-arg, though, because we need to preserve the
+    // values in `have` that are not managed by the
+    // `expected` schema.
 
     failure |= check_scalar(filepath, have, expected, "", merged, "layout");
     failure |= check_scalar(filepath, have, expected, "", merged, "title");
     failure |= check_scalar(filepath, have, expected, "", merged, "owner");
     failure |= check_scalar(filepath, have, expected, "", merged, "brief");
-    // failure |= check_array(filepath, have, expected, "", merged, "tags");
+    failure |= check_scalar_array(filepath, have, expected, "", merged, "tags");
 
     failure |= do_merge(filepath, have, expected, merged);
 
@@ -897,15 +1068,22 @@ void yaml_base_emitter::maybe_annotate(const json& j, json& node) {
 
     if (j.count("default") && j["default"])
         node["annotation"].push_back("default");
+    else if (j.count("compiler-default") && j["compiler-default"])
+        node["annotation"].push_back("compiler-default");
     else if (j.count("delete") && j["delete"])
         node["annotation"].push_back("delete");
+    else if (j.count("compiler-delete") && j["compiler-delete"])
+        node["annotation"].push_back("compiler-delete");
 
     if (j.count("deprecated") && j["deprecated"]) {
         std::string deprecated("deprecated");
         if (j.count("deprecated_message")) {
-            deprecated = deprecated.append(" (")
-                             .append(static_cast<const std::string&>(j["deprecated_message"]))
-                             .append(")");
+            const std::string& message_str = j["deprecated_message"];
+            if (!message_str.empty()) {
+                deprecated = deprecated.append(" (")
+                                 .append(message_str)
+                                 .append(")");
+            }
         }
         node["annotation"].push_back(deprecated);
     }

--- a/emitters/yaml_base_emitter.cpp
+++ b/emitters/yaml_base_emitter.cpp
@@ -791,6 +791,8 @@ std::pair<bool, json> yaml_base_emitter::merge(const std::string& filepath,
                                                const json& expected) {
     bool failure{false};
     
+    // Create a temporary object with the json to merge as a value so we can use `check_map`
+    // to make sure removed keys are handled
     static const auto root_key = "<root>";
     json merged_root = hyde::json::object();
     json have_root = hyde::json::object();

--- a/emitters/yaml_base_emitter.cpp
+++ b/emitters/yaml_base_emitter.cpp
@@ -24,6 +24,7 @@ written permission of Adobe.
 // application
 #include "emitters/yaml_base_emitter_fwd.hpp"
 #include "json.hpp"
+#include "matchers/utilities.hpp"
 
 /**************************************************************************************************/
 
@@ -257,13 +258,16 @@ void yaml_base_emitter::check_notify(const std::string& filepath,
                                      const std::string& key,
                                      const std::string& validate_message,
                                      const std::string& update_message) {
+    std::string escaped_nodepath = hyde::ReplaceAll(nodepath, "\n", "\\n");
+    std::string escaped_key = hyde::ReplaceAll(key, "\n", "\\n");
+    
     switch (_mode) {
         case yaml_mode::validate: {
-            std::cerr << filepath << "@" << nodepath << "['" << key << "']: " << validate_message
+            std::cerr << filepath << "@" << escaped_nodepath << "['" << escaped_key << "']: " << validate_message
                       << "\n";
         } break;
         case yaml_mode::update: {
-            std::cout << filepath << "@" << nodepath << "['" << key << "']: " << update_message
+            std::cout << filepath << "@" << escaped_nodepath << "['" << escaped_key << "']: " << update_message
                       << "\n";
         } break;
     }

--- a/emitters/yaml_base_emitter.cpp
+++ b/emitters/yaml_base_emitter.cpp
@@ -275,6 +275,21 @@ void yaml_base_emitter::check_notify(const std::string& filepath,
 
 /**************************************************************************************************/
 
+bool yaml_base_emitter::check_removed(const std::string& filepath,
+                                      const json& have_node,
+                                      const std::string& nodepath,
+                                      const std::string& key) {
+    if (!have_node.count(key)) {
+        // Removed key not present in have. Do nothing, no error.
+        return false;
+    } else {
+        check_notify(filepath, nodepath, key, "value present for removed key", "value removed");
+        return true;
+    }
+}
+
+/**************************************************************************************************/
+
 bool yaml_base_emitter::check_scalar(const std::string& filepath,
                                      const json& have_node,
                                      const json& expected_node,
@@ -287,13 +302,7 @@ bool yaml_base_emitter::check_scalar(const std::string& filepath,
     };
 
     if (!expected_node.count(key)) {
-        if (!have_node.count(key)) {
-            // Removed key not present in have. Do nothing, no error.
-            return false;
-        } else {
-            notify("value present for removed key", "value removed");
-            return true;
-        }
+        return check_removed(filepath, have_node, nodepath, key);
     }
 
     const json& expected = expected_node[key];
@@ -333,8 +342,6 @@ bool yaml_base_emitter::check_scalar(const std::string& filepath,
 
 /**************************************************************************************************/
 
-/**************************************************************************************************/
-
 bool yaml_base_emitter::check_editable_scalar(const std::string& filepath,
                                               const json& have_node,
                                               const json& expected_node,
@@ -347,13 +354,7 @@ bool yaml_base_emitter::check_editable_scalar(const std::string& filepath,
     };
 
     if (!expected_node.count(key)) {
-        if (!have_node.count(key)) {
-            // Removed key not present in have. Do nothing, no error.
-            return false;
-        } else {
-            notify("value present for removed key", "value removed");
-            return true;
-        }
+        return check_removed(filepath, have_node, nodepath, key);
     }
 
     const json& expected = expected_node[key];
@@ -441,13 +442,7 @@ bool yaml_base_emitter::check_editable_scalar_array(const std::string& filepath,
     };
 
     if (!expected_node.count(key)) {
-        if (!have_node.count(key)) {
-            // Removed key not present in have. Do nothing, no error.
-            return false;
-        } else {
-            notify("value present for removed key", "value removed");
-            return true;
-        }
+        return check_removed(filepath, have_node, nodepath, key);
     }
 
     const json& expected = expected_node[key];
@@ -675,13 +670,7 @@ bool yaml_base_emitter::check_object_array(const std::string& filepath,
     };
 
     if (!expected_node.count(key)) {
-        if (!have_node.count(key)) {
-            // Removed key not present in have. Do nothing, no error.
-            return false;
-        } else {
-            notify("value present for removed key", "value removed");
-            return true;
-        }
+        return check_removed(filepath, have_node, nodepath, key);
     }
 
     const json& expected = expected_node[key];
@@ -817,13 +806,7 @@ bool yaml_base_emitter::check_map(const std::string& filepath,
     };
 
     if (!expected_node.count(key)) {
-        if (!have_node.count(key)) {
-            // Removed key not present in have. Do nothing, no error.
-            return false;
-        } else {
-            notify("value present for removed key", "value removed");
-            return true;
-        }
+        return check_removed(filepath, have_node, nodepath, key);
     }
 
     const json& expected = expected_node[key];

--- a/emitters/yaml_base_emitter.cpp
+++ b/emitters/yaml_base_emitter.cpp
@@ -1070,12 +1070,8 @@ void yaml_base_emitter::maybe_annotate(const json& j, json& node) {
 
     if (j.count("default") && j["default"])
         node["annotation"].push_back("default");
-    else if (j.count("compiler-default") && j["compiler-default"])
-        node["annotation"].push_back("compiler-default");
     else if (j.count("delete") && j["delete"])
         node["annotation"].push_back("delete");
-    else if (j.count("compiler-delete") && j["compiler-delete"])
-        node["annotation"].push_back("compiler-delete");
 
     if (j.count("deprecated") && j["deprecated"]) {
         std::string deprecated("deprecated");

--- a/emitters/yaml_base_emitter.hpp
+++ b/emitters/yaml_base_emitter.hpp
@@ -89,16 +89,21 @@ protected:
     template <typename... Args>
     boost::filesystem::path dst_path(const json& j, Args&&... args);
 
+    bool check_removed(const std::string& filepath,
+                       const json& have_node,
+                       const std::string& nodepath,
+                       const std::string& key);
+
     bool check_scalar(const std::string& filepath,
-                      const json& have,
-                      const json& expected,
+                      const json& have_node,
+                      const json& expected_node,
                       const std::string& nodepath,
                       json& out_merged,
                       const std::string& key);
 
     bool check_editable_scalar(const std::string& filepath,
-                               const json& have,
-                               const json& expected,
+                               const json& have_node,
+                               const json& expected_node,
                                const std::string& nodepath,
                                json& out_merged,
                                const std::string& key);

--- a/emitters/yaml_base_emitter.hpp
+++ b/emitters/yaml_base_emitter.hpp
@@ -80,6 +80,12 @@ protected:
 
     void insert_typedefs(const json& j, json& node);
 
+    bool check_typedefs(const std::string& filepath,
+                        const json& have_node,
+                        const json& expected_node,
+                        const std::string& nodepath,
+                        json& merged_node);
+
     template <typename... Args>
     boost::filesystem::path dst_path(const json& j, Args&&... args);
 
@@ -90,12 +96,19 @@ protected:
                       json& out_merged,
                       const std::string& key);
 
-    bool check_ungenerated_scalar_array(const std::string& filepath,
-                                        const json& have_node,
-                                        const json& expected_node,
-                                        const std::string& nodepath,
-                                        json& merged_node,
-                                        const std::string& key);
+    bool check_editable_scalar(const std::string& filepath,
+                               const json& have,
+                               const json& expected,
+                               const std::string& nodepath,
+                               json& out_merged,
+                               const std::string& key);
+
+    bool check_editable_scalar_array(const std::string& filepath,
+                                     const json& have_node,
+                                     const json& expected_node,
+                                     const std::string& nodepath,
+                                     json& merged_node,
+                                     const std::string& key);
 
     bool check_scalar_array(const std::string& filepath,
                             const json& have_node,

--- a/emitters/yaml_base_emitter.hpp
+++ b/emitters/yaml_base_emitter.hpp
@@ -90,6 +90,13 @@ protected:
                       json& out_merged,
                       const std::string& key);
 
+    bool check_ungenerated_scalar_array(const std::string& filepath,
+                                        const json& have_node,
+                                        const json& expected_node,
+                                        const std::string& nodepath,
+                                        json& merged_node,
+                                        const std::string& key);
+
     bool check_scalar_array(const std::string& filepath,
                             const json& have_node,
                             const json& expected_node,
@@ -164,8 +171,8 @@ template <typename... Args>
 boost::filesystem::path yaml_base_emitter::dst_path(const json& j, Args&&... args) {
     boost::filesystem::path result(_dst_root);
 
-    if (j.count("defined-in-file")) {
-        const std::string& defined_in_file = j["defined-in-file"];
+    if (j.count("defined_in_file")) {
+        const std::string& defined_in_file = j["defined_in_file"];
         result /= directory_mangle(subcomponent(defined_in_file, _src_root));
     }
 

--- a/emitters/yaml_class_emitter.cpp
+++ b/emitters/yaml_class_emitter.cpp
@@ -30,49 +30,40 @@ bool yaml_class_emitter::do_merge(const std::string& filepath,
                                   json& out_merged) {
     bool failure{false};
 
-    failure |= check_scalar(filepath, have, expected, "", out_merged, "defined-in-file");
-    // failure |= check_scalar(filepath, have, expected, "", out_merged, "annotation");
+    failure |= check_scalar(filepath, have, expected, "", out_merged, "defined_in_file");
+    failure |= check_scalar_array(filepath, have, expected, "", out_merged, "annotation");
     failure |= check_scalar(filepath, have, expected, "", out_merged, "declaration");
     // failure |= check_array(filepath, have, expected, "", out_merged, "namespace");
-    if (expected.count("ctor"))
-        failure |= check_scalar(filepath, have, expected, "", out_merged, "ctor");
-    if (expected.count("dtor"))
-        failure |= check_scalar(filepath, have, expected, "", out_merged, "dtor");
+    failure |= check_scalar(filepath, have, expected, "", out_merged, "ctor");
+    failure |= check_scalar(filepath, have, expected, "", out_merged, "dtor");
+    failure |= check_map(
+        filepath, have, expected, "", out_merged, "fields",
+        [this](const std::string& filepath, const json& have, const json& expected,
+               const std::string& nodepath, json& out_merged) {
+            bool failure{false};
 
-    if (expected.count("fields")) {
-        failure |= check_map(
-            filepath, have, expected, "", out_merged, "fields",
-            [this](const std::string& filepath, const json& have, const json& expected,
-                   const std::string& nodepath, json& out_merged) {
-                bool failure{false};
+            failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "type");
+            failure |=
+                check_scalar(filepath, have, expected, nodepath, out_merged, "description");
+            failure |= check_scalar_array(filepath, have, expected, nodepath, out_merged, "annotation");
 
-                failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "type");
-                failure |=
-                    check_scalar(filepath, have, expected, nodepath, out_merged, "description");
-                // failure |= check_scalar(filepath, have, expected, nodepath, out_merged,
-                // "annotation");
+            return failure;
+        });
 
-                return failure;
-            });
-    }
+    failure |= check_map(
+        filepath, have, expected, "", out_merged, "typedefs",
+        [this](const std::string& filepath, const json& have, const json& expected,
+               const std::string& nodepath, json& out_merged) {
+            bool failure{false};
 
-    if (expected.count("typedefs")) {
-        failure |= check_map(
-            filepath, have, expected, "", out_merged, "typedefs",
-            [this](const std::string& filepath, const json& have, const json& expected,
-                   const std::string& nodepath, json& out_merged) {
-                bool failure{false};
+            failure |=
+                check_scalar(filepath, have, expected, nodepath, out_merged, "definition");
+            failure |=
+                check_scalar(filepath, have, expected, nodepath, out_merged, "description");
+            failure |= check_scalar_array(filepath, have, expected, nodepath, out_merged, "annotation");
 
-                failure |=
-                    check_scalar(filepath, have, expected, nodepath, out_merged, "definition");
-                failure |=
-                    check_scalar(filepath, have, expected, nodepath, out_merged, "description");
-                // failure |= check_scalar(filepath, have, expected, nodepath, out_merged,
-                // "annotation");
-
-                return failure;
-            });
-    }
+            return failure;
+        });
 
     return failure;
 }
@@ -81,7 +72,7 @@ bool yaml_class_emitter::do_merge(const std::string& filepath,
 
 bool yaml_class_emitter::emit(const json& j, json& out_emitted) {
     json node = base_emitter_node("class", j["name"], "class");
-    node["defined-in-file"] = defined_in_file(j["defined-in-file"], _src_root);
+    node["defined_in_file"] = defined_in_file(j["defined_in_file"], _src_root);
     maybe_annotate(j, node);
 
     std::string declaration = format_template_parameters(j, true) + '\n' +

--- a/emitters/yaml_class_emitter.cpp
+++ b/emitters/yaml_class_emitter.cpp
@@ -33,7 +33,7 @@ bool yaml_class_emitter::do_merge(const std::string& filepath,
     failure |= check_scalar(filepath, have, expected, "", out_merged, "defined_in_file");
     failure |= check_scalar_array(filepath, have, expected, "", out_merged, "annotation");
     failure |= check_scalar(filepath, have, expected, "", out_merged, "declaration");
-    // failure |= check_array(filepath, have, expected, "", out_merged, "namespace");
+    failure |= check_scalar_array(filepath, have, expected, "", out_merged, "namespace");
     failure |= check_scalar(filepath, have, expected, "", out_merged, "ctor");
     failure |= check_scalar(filepath, have, expected, "", out_merged, "dtor");
     failure |= check_map(

--- a/emitters/yaml_class_emitter.cpp
+++ b/emitters/yaml_class_emitter.cpp
@@ -43,26 +43,20 @@ bool yaml_class_emitter::do_merge(const std::string& filepath,
             bool failure{false};
 
             failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "type");
-            failure |=
-                check_scalar(filepath, have, expected, nodepath, out_merged, "description");
+            failure |= check_editable_scalar(filepath, have, expected, nodepath, out_merged, "description");
             failure |= check_scalar_array(filepath, have, expected, nodepath, out_merged, "annotation");
 
             return failure;
         });
 
-    failure |= check_map(
-        filepath, have, expected, "", out_merged, "typedefs",
+    failure |= check_typedefs(filepath, have, expected, "", out_merged);
+    
+    failure |= check_object_array(
+        filepath, have, expected, "", out_merged, "methods", "title",
         [this](const std::string& filepath, const json& have, const json& expected,
                const std::string& nodepath, json& out_merged) {
-            bool failure{false};
-
-            failure |=
-                check_scalar(filepath, have, expected, nodepath, out_merged, "definition");
-            failure |=
-                check_scalar(filepath, have, expected, nodepath, out_merged, "description");
-            failure |= check_scalar_array(filepath, have, expected, nodepath, out_merged, "annotation");
-
-            return failure;
+            yaml_function_emitter function_emitter(_src_root, _dst_root, _mode, _options, true);
+            return function_emitter.do_merge(filepath, have, expected, out_merged);
         });
 
     return failure;

--- a/emitters/yaml_enum_emitter.cpp
+++ b/emitters/yaml_enum_emitter.cpp
@@ -35,7 +35,13 @@ bool yaml_enum_emitter::do_merge(const std::string& filepath,
         filepath, have, expected, "", out_merged, "values", "name",
         [this](const std::string& filepath, const json& have, const json& expected,
                const std::string& nodepath, json& out_merged) {
-            return check_scalar(filepath, have, expected, nodepath, out_merged, "description");
+            bool failure{false};
+            
+            failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "name");
+            failure |= check_editable_scalar(filepath, have, expected, nodepath, out_merged, "description");
+            failure |= check_scalar_array(filepath, have, expected, "", out_merged, "values");
+            
+            return failure;
         });
 
     return failure;
@@ -49,15 +55,17 @@ bool yaml_enum_emitter::emit(const json& j, json& out_emitted) {
     // Most likely an enum forward declaration. Nothing to document here.
     if (j["values"].empty()) return true;
 
-    std::string filename;
-    for (const auto& ns : j["namespaces"]) {
-        filename += static_cast<const std::string&>(ns) + "::";
-    }
-    filename = filename_filter(std::move(filename) + name) + ".md";
-
     json node = base_emitter_node("enumeration", j["name"], "enumeration");
     node["defined_in_file"] = defined_in_file(j["defined_in_file"], _src_root);
     maybe_annotate(j, node);
+    
+    std::string filename;
+    for (const auto& ns : j["namespaces"]) {
+        const std::string& namespace_str = ns;
+        node["namespace"].push_back(namespace_str);
+        filename += namespace_str + "::";
+    }
+    filename = filename_filter(std::move(filename) + name) + ".md";
 
     for (const auto& value : j["values"]) {
         json cur_value;

--- a/emitters/yaml_enum_emitter.cpp
+++ b/emitters/yaml_enum_emitter.cpp
@@ -29,6 +29,7 @@ bool yaml_enum_emitter::do_merge(const std::string& filepath,
 
     failure |= check_scalar(filepath, have, expected, "", out_merged, "defined_in_file");
     failure |= check_scalar_array(filepath, have, expected, "", out_merged, "annotation");
+    failure |= check_scalar_array(filepath, have, expected, "", out_merged, "namespace");
 
     failure |= check_object_array(
         filepath, have, expected, "", out_merged, "values", "name",

--- a/emitters/yaml_enum_emitter.cpp
+++ b/emitters/yaml_enum_emitter.cpp
@@ -27,8 +27,8 @@ bool yaml_enum_emitter::do_merge(const std::string& filepath,
                                  json& out_merged) {
     bool failure{false};
 
-    failure |= check_scalar(filepath, have, expected, "", out_merged, "defined-in-file");
-    // failure |= check_scalar(filepath, have, expected, "", out_merged, "annotation");
+    failure |= check_scalar(filepath, have, expected, "", out_merged, "defined_in_file");
+    failure |= check_scalar_array(filepath, have, expected, "", out_merged, "annotation");
 
     failure |= check_object_array(
         filepath, have, expected, "", out_merged, "values", "name",
@@ -55,7 +55,7 @@ bool yaml_enum_emitter::emit(const json& j, json& out_emitted) {
     filename = filename_filter(std::move(filename) + name) + ".md";
 
     json node = base_emitter_node("enumeration", j["name"], "enumeration");
-    node["defined-in-file"] = defined_in_file(j["defined-in-file"], _src_root);
+    node["defined_in_file"] = defined_in_file(j["defined_in_file"], _src_root);
     maybe_annotate(j, node);
 
     for (const auto& value : j["values"]) {

--- a/emitters/yaml_function_emitter.cpp
+++ b/emitters/yaml_function_emitter.cpp
@@ -27,8 +27,7 @@ bool yaml_function_emitter::do_merge(const std::string& filepath,
                                      json& out_merged) {
     bool failure{false};
 
-    failure |= check_scalar(filepath, have, expected, "", out_merged, "defined-in-file");
-    // failure |= check_scalar(filepath, have, expected, "", out_merged, "annotation");
+    failure |= check_scalar(filepath, have, expected, "", out_merged, "defined_in_file");
     failure |= check_map(
         filepath, have, expected, "", out_merged, "overloads",
         [this](const std::string& filepath, const json& have, const json& expected,
@@ -39,26 +38,24 @@ bool yaml_function_emitter::do_merge(const std::string& filepath,
             failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "signature_with_names");
             failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "return");
             if (_options._tested_by != hyde::attribute_category::disabled) {
-                failure |= check_scalar_array(filepath, have, expected, nodepath, out_merged, "tested_by");
+                failure |= check_ungenerated_scalar_array(filepath, have, expected, nodepath, out_merged, "tested_by");
             }
-            // failure |= check_scalar(filepath, have, expected, nodepath, out_merged,
-            // "annotation");
+            
+            failure |= check_scalar_array(filepath, have, expected, nodepath, out_merged, "annotation");
 
-            if (expected.count("arguments")) {
-                failure |= check_object_array(
-                    filepath, have, expected, nodepath, out_merged, "arguments", "name",
-                    [this](const std::string& filepath, const json& have, const json& expected,
-                           const std::string& nodepath, json& out_merged) {
-                        bool failure{false};
+            failure |= check_object_array(
+                filepath, have, expected, nodepath, out_merged, "arguments", "name",
+                [this](const std::string& filepath, const json& have, const json& expected,
+                       const std::string& nodepath, json& out_merged) {
+                    bool failure{false};
 
-                        failure |=
-                            check_scalar(filepath, have, expected, nodepath, out_merged, "type");
-                        failure |= check_scalar(filepath, have, expected, nodepath, out_merged,
-                                                "description");
+                    failure |=
+                        check_scalar(filepath, have, expected, nodepath, out_merged, "type");
+                    failure |= check_scalar(filepath, have, expected, nodepath, out_merged,
+                                            "description");
 
-                        return failure;
-                    });
-            }
+                    return failure;
+                });
 
             return failure;
         });
@@ -87,7 +84,7 @@ bool yaml_function_emitter::emit(const json& jsn, json& out_emitted) {
             name = overload["short_name"];
             // prefix to keep free-function from colliding with class member (e.g., `swap`)
             filename = (_as_methods ? "m_" : "f_") + filename_filter(name);
-            defined_path = defined_in_file(overload["defined-in-file"], _src_root);
+            defined_path = defined_in_file(overload["defined_in_file"], _src_root);
             if (overload.count("is_ctor") && overload["is_ctor"]) is_ctor = true;
             if (overload.count("is_dtor") && overload["is_dtor"]) is_dtor = true;
         }
@@ -122,7 +119,7 @@ bool yaml_function_emitter::emit(const json& jsn, json& out_emitted) {
 
     json node = base_emitter_node(_as_methods ? "method" : "function", name,
                                   _as_methods ? "method" : "function");
-    node["defined-in-file"] = defined_path;
+    node["defined_in_file"] = defined_path;
     maybe_annotate(jsn, node);
     node["overloads"] = std::move(overloads);
     if (is_ctor) node["is_ctor"] = true;

--- a/emitters/yaml_function_emitter.cpp
+++ b/emitters/yaml_function_emitter.cpp
@@ -29,17 +29,19 @@ bool yaml_function_emitter::do_merge(const std::string& filepath,
 
     failure |= check_scalar(filepath, have, expected, "", out_merged, "defined_in_file");
     failure |= check_scalar_array(filepath, have, expected, "", out_merged, "namespace");
+    failure |= check_scalar(filepath, have, expected, "", out_merged, "is_ctor");
+    failure |= check_scalar(filepath, have, expected, "", out_merged, "is_dtor");
     failure |= check_map(
         filepath, have, expected, "", out_merged, "overloads",
         [this](const std::string& filepath, const json& have, const json& expected,
                const std::string& nodepath, json& out_merged) {
             bool failure{false};
 
-            failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "description");
+            failure |= check_editable_scalar(filepath, have, expected, nodepath, out_merged, "description");
             failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "signature_with_names");
-            failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "return");
+            failure |= check_editable_scalar(filepath, have, expected, nodepath, out_merged, "return");
             if (_options._tested_by != hyde::attribute_category::disabled) {
-                failure |= check_ungenerated_scalar_array(filepath, have, expected, nodepath, out_merged, "tested_by");
+                failure |= check_editable_scalar_array(filepath, have, expected, nodepath, out_merged, "tested_by");
             }
             
             failure |= check_scalar_array(filepath, have, expected, nodepath, out_merged, "annotation");
@@ -50,10 +52,10 @@ bool yaml_function_emitter::do_merge(const std::string& filepath,
                        const std::string& nodepath, json& out_merged) {
                     bool failure{false};
 
-                    failure |=
-                        check_scalar(filepath, have, expected, nodepath, out_merged, "type");
-                    failure |= check_scalar(filepath, have, expected, nodepath, out_merged,
-                                            "description");
+                    failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "name");
+                    failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "type");
+                    failure |= check_editable_scalar(filepath, have, expected, nodepath, out_merged, "description");
+                    failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "unnamed");
 
                     return failure;
                 });

--- a/emitters/yaml_library_emitter.cpp
+++ b/emitters/yaml_library_emitter.cpp
@@ -29,7 +29,7 @@ bool yaml_library_emitter::do_merge(const std::string& filepath,
 
     failure |= check_scalar(filepath, have, expected, "", out_merged, "library-type");
     failure |= check_scalar(filepath, have, expected, "", out_merged, "icon");
-    failure |= check_scalar(filepath, have, expected, "", out_merged, "tab");
+    failure |= check_editable_scalar(filepath, have, expected, "", out_merged, "tab");
 
     return failure;
 }

--- a/emitters/yaml_sourcefile_emitter.cpp
+++ b/emitters/yaml_sourcefile_emitter.cpp
@@ -31,19 +31,7 @@ bool yaml_sourcefile_emitter::do_merge(const std::string& filepath,
     bool failure{false};
 
     failure |= check_scalar(filepath, have, expected, "", out_merged, "library-type");
-
-    failure |= check_map(
-        filepath, have, expected, "", out_merged, "typedefs",
-        [this](const std::string& filepath, const json& have, const json& expected,
-               const std::string& nodepath, json& out_merged) {
-            bool failure{false};
-
-            failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "definition");
-            failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "description");
-            failure |= check_scalar_array(filepath, have, expected, nodepath, out_merged, "annotation");
-
-            return failure;
-        });
+    failure |= check_typedefs(filepath, have, expected, "", out_merged);
 
     return failure;
 }

--- a/emitters/yaml_sourcefile_emitter.cpp
+++ b/emitters/yaml_sourcefile_emitter.cpp
@@ -32,20 +32,18 @@ bool yaml_sourcefile_emitter::do_merge(const std::string& filepath,
 
     failure |= check_scalar(filepath, have, expected, "", out_merged, "library-type");
 
-    if (expected.count("typedefs")) {
-        failure |= check_map(
-            filepath, have, expected, "", out_merged, "typedefs",
-            [this](const std::string& filepath, const json& have, const json& expected,
-                   const std::string& nodepath, json& out_merged) {
-                bool failure{false};
+    failure |= check_map(
+        filepath, have, expected, "", out_merged, "typedefs",
+        [this](const std::string& filepath, const json& have, const json& expected,
+               const std::string& nodepath, json& out_merged) {
+            bool failure{false};
 
-                failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "definition");
-                failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "description");
-                // failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "annotation");
+            failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "definition");
+            failure |= check_scalar(filepath, have, expected, nodepath, out_merged, "description");
+            failure |= check_scalar_array(filepath, have, expected, nodepath, out_merged, "annotation");
 
-                return failure;
-            });
-    }
+            return failure;
+        });
 
     return failure;
 }

--- a/matchers/utilities.cpp
+++ b/matchers/utilities.cpp
@@ -462,7 +462,15 @@ boost::optional<json> DetailFunctionDecl(const hyde::processing_options& options
             }
             if (is_dtor) info["is_dtor"] = true;
             if (method->isDeletedAsWritten()) info["delete"] = true;
+            if (method->isDeleted() && !method->isDeletedAsWritten()) {
+                // Method implicitly deleted by compiler (vs. an explicit ` = delete` declaration)
+                info["compiler-delete"] = true;
+            }
             if (method->isExplicitlyDefaulted()) info["default"] = true;
+            if (method->isDefaulted() && !method->isExplicitlyDefaulted()) {
+                // Method implicitly added by compiler (vs. an explicit ` = default` declaration)
+                info["compiler-default"] = true;
+            }
         }
 
         if (auto conversion_decl = llvm::dyn_cast_or_null<CXXConversionDecl>(method)) {

--- a/matchers/utilities.cpp
+++ b/matchers/utilities.cpp
@@ -635,15 +635,19 @@ std::string PostProcessTypeParameter(const clang::Decl* decl, std::string type) 
 
 /**************************************************************************************************/
 
-std::string PostProcessSpacing(std::string type) {
+std::string ReplaceAll(std::string str, const std::string& substr, const std::string& replacement) {
     std::string::size_type pos{0};
 
     while (true) {
-        pos = type.find("> >", pos);
-        if (pos == std::string::npos) return type;
-        type.replace(pos, 3, ">>");
-        pos += 2;
+        pos = str.find(substr, pos);
+        if (pos == std::string::npos) return str;
+        str.replace(pos, substr.size(), replacement);
+        pos += replacement.size();
     }
+}
+
+std::string PostProcessSpacing(std::string type) {
+    return ReplaceAll(type, "> >", ">>");
 }
 
 /**************************************************************************************************/

--- a/matchers/utilities.cpp
+++ b/matchers/utilities.cpp
@@ -462,15 +462,7 @@ boost::optional<json> DetailFunctionDecl(const hyde::processing_options& options
             }
             if (is_dtor) info["is_dtor"] = true;
             if (method->isDeletedAsWritten()) info["delete"] = true;
-            if (method->isDeleted() && !method->isDeletedAsWritten()) {
-                // Method implicitly deleted by compiler (vs. an explicit ` = delete` declaration)
-                info["compiler-delete"] = true;
-            }
             if (method->isExplicitlyDefaulted()) info["default"] = true;
-            if (method->isDefaulted() && !method->isExplicitlyDefaulted()) {
-                // Method implicitly added by compiler (vs. an explicit ` = default` declaration)
-                info["compiler-default"] = true;
-            }
         }
 
         if (auto conversion_decl = llvm::dyn_cast_or_null<CXXConversionDecl>(method)) {

--- a/matchers/utilities.hpp
+++ b/matchers/utilities.hpp
@@ -101,11 +101,10 @@ boost::optional<json> StandardDeclInfo(const hyde::processing_options& options,
 
     if (!AccessCheck(options._access_filter, clang_access)) return boost::optional<json>();
 
-    if (clang_access != clang::AccessSpecifier::AS_none &&
-        clang_access != clang::AccessSpecifier::AS_public)
+    if (clang_access != clang::AccessSpecifier::AS_none)
         info["access"] = to_string(clang_access);
 
-    info["defined-in-file"] = [&] {
+    info["defined_in_file"] = [&] {
         auto beginLoc = d->getBeginLoc();
         auto location = beginLoc.printToString(n->getSourceManager());
         return location.substr(0, location.find(':'));

--- a/matchers/utilities.hpp
+++ b/matchers/utilities.hpp
@@ -52,6 +52,8 @@ bool NamespaceBlacklist(const std::vector<std::string>& blacklist, const json& j
 
 std::string GetArgumentList(const llvm::ArrayRef<clang::NamedDecl*> args);
 
+std::string ReplaceAll(std::string str, const std::string& substr, const std::string& replacement);
+
 // type-parameter-N-M filtering.
 std::string PostProcessType(const clang::Decl* decl, std::string type);
 


### PR DESCRIPTION
Make sure all elements get validated/updated.

 Before, many elements generated as part of the non-editable documentation weren't checked during yaml emit. This meant that many elements of Hyde documentation that have changed over time or where the header declarations changed were never updated in existing documentation. Also, extraneous elements were never removed from many elements.

Also:
- Renamed `defined-in-file` element for consistency
- Escape newlines in notification strings
- Added namespace element to everything except class members