### PR TITLE
Directory stub needs to contain a title

### DIFF
--- a/emitters/yaml_base_emitter.cpp
+++ b/emitters/yaml_base_emitter.cpp
@@ -955,6 +955,7 @@ bool yaml_base_emitter::create_directory_stub(boost::filesystem::path p) {
 
     static const auto stub_json_k = json::object_t{
         {"layout", "directory"},
+        {"title", p.filename().string()},
     };
 
     output << front_matter_delimiter_k;


### PR DESCRIPTION
Add a title field to the directory stub with the directory name as the value.