### PR TITLE
Fix various build problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ target_include_directories(hyde PUBLIC ${LLVM_INCLUDE_DIRS})
 target_include_directories(hyde PUBLIC ${PROJECT_SOURCE_DIR}/submodules/yaml-cpp/include/)
 target_include_directories(hyde PUBLIC ${PROJECT_SOURCE_DIR}/submodules/json/include/)
 
-target_compile_options(hyde PUBLIC -Wall -Werror -Wno-range-loop-analysis -DHYDE_FORCE_BOOST_FILESYSTEM=1)
+target_compile_options(hyde PUBLIC -Wall -Wno-comment -Werror -Wno-range-loop-analysis -DHYDE_FORCE_BOOST_FILESYSTEM=1)
 
 target_link_libraries(hyde
                       ${Boost_FILESYSTEM_LIBRARY}

--- a/emitters/yaml_base_emitter.cpp
+++ b/emitters/yaml_base_emitter.cpp
@@ -87,6 +87,7 @@ hyde::json yaml_to_json(const YAML::Node& yaml) {
             throw std::runtime_error("YAML is not defined!");
         } break;
     }
+    return hyde::json();
 }
 
 /**************************************************************************************************/
@@ -132,6 +133,7 @@ YAML::Node json_to_yaml(const hyde::json& json) {
             throw std::runtime_error("Discarded JSON value");
         } break;
     }
+    return YAML::Node();
 }
 
 /**************************************************************************************************/

--- a/matchers/utilities.cpp
+++ b/matchers/utilities.cpp
@@ -554,6 +554,8 @@ bool AccessCheck(ToolAccessFilter hyde_filter, clang::AccessSpecifier clang_acce
                     return false;
             }
     }
+
+    return false;
 }
 
 /**************************************************************************************************/

--- a/matchers/utilities.hpp
+++ b/matchers/utilities.hpp
@@ -70,6 +70,7 @@ inline std::string to_string(clang::AccessSpecifier access) {
         case clang::AccessSpecifier::AS_none:
             return "none";
     }
+    return "unknown";
 }
 
 /**************************************************************************************************/


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

 - Ignoring a multiline comment in LLVM9 as a `-Wno-commend` in the `CMakeLists.txt`
 - Adding return statements to methods where gcc cannot deduct that a case will always result in a return being executed.

## Related Issue

https://github.com/adobe/hyde/issues/69

## Motivation and Context

*Why is this change required?* This change is required to build on Ubuntu 20.04 with LLVM9
*What problem does it solve? * This enables building on Ubuntu 20.04 with LLMV9

## How Has This Been Tested?
I didn't find any automated tests to fun, but I ran the 

## Screenshots (if appropriate):
N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] N/A ~~I have added tests to cover my changes.~~
- [X] N/A- I could not find any tests to run. ~~All new and existing tests passed.~~
