### PR TITLE
LLVM 13 Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 .vscode/
 build/
+build*/
 docs/_site/
 docs/Gemfile.lock
 docs/libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,22 +16,19 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(APPLE)
     # for now we are assuming the user has installed with homebrew.
-    # homebrew installs into /usr/local/Cellar/llvm/{version}
-    # CMAKE_PREFIX_PATH isn't recursive so it isn't possible to find it :(
-    # this attempts to find out what the user intended
-    # future improvments:
-    # allow a variable to set the version
-    # check a variable to use non homebrew installs
-    # this code also assumes the user hasn't added anything them selves into the homebrew llvm directory
-    FILE(GLOB llvm_version_dir relative "/usr/local/Cellar/llvm/*")
-    LIST(SORT llvm_version_dir)
-    #reverse it so we can get the most recent at index 0 (no need to find the length)
-    LIST(REVERSE llvm_version_dir)
-    LIST(GET llvm_version_dir 0 llvm_to_use)
+    # we detect the install location with brew --prefix llvm
+    execute_process(
+        COMMAND brew --prefix llvm
+        OUTPUT_VARIABLE llvm_to_use
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
     message(STATUS "using this version of llvm: ${llvm_to_use}")
 
     set(Clang_DIR ${llvm_to_use}/lib/cmake/clang/)
+    message(STATUS "Clang_DIR set to ${Clang_DIR}")
+
     set(LLVM_DIR ${llvm_to_use}/lib/cmake/llvm/)
+    message(STATUS "LLVM_DIR set to ${LLVM_DIR}")
 endif()
 
 find_package(Clang REQUIRED clangTooling libClang clangASTMatchers)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,24 @@
 
-FROM ubuntu:latest
+FROM --platform=linux/x86_64 ubuntu:latest
 RUN apt-get -y update && apt-get install -y
 
 RUN apt-get -y install curl gnupg2 software-properties-common ninja-build  apt-utils make
 
-# install clang/llvm 8 
-RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main"
-RUN apt-get -y update && apt-get install -y
-RUN apt-get -y install libllvm8 llvm-8 llvm-8-dev
-RUN apt-get -y install clang-8 clang-tools-8 libclang-common-8-dev libclang-8-dev libclang1-8
-RUN apt-get -y install libc++-8-dev libc++abi-8-dev
+RUN apt-get -y install wget
 
-#set clang 8 to be the version of clang we use when clang/clang++ is invoked
-RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-8 100
-RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100
+# Install llvm/clang 13
 
-ADD https://cmake.org/files/v3.13/cmake-3.13.0-Linux-x86_64.sh /cmake-3.13.0-Linux-x86_64.sh
+RUN wget https://apt.llvm.org/llvm.sh
+RUN chmod +x llvm.sh
+RUN ./llvm.sh 13 all
+
+# set clang 13 to be the version of clang we use when clang/clang++ is invoked
+RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-13 100
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-13 100
+
+ADD https://cmake.org/files/v3.18/cmake-3.18.0-Linux-x86_64.sh /cmake-3.18.0-Linux-x86_64.sh
 RUN mkdir /opt/cmake
-RUN sh /cmake-3.13.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license
+RUN sh /cmake-3.18.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license
 RUN ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
 
 #install hyde dependencies 
@@ -33,5 +33,8 @@ RUN mkdir -p build \
     && rm -rf *  \
     && cmake .. -GNinja \
     && ninja 
-WORKDIR /usr/src/hyde
+
+# install hyde
+RUN cp ./build/hyde /usr/bin
+
 CMD ["./generate_test_files.sh"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ note only tested on ubuntu bionic so far
 - `cmake .. -GNinja` (or `-GXcode`, etc.)
 - `ninja` (or whatever your IDE does)
 
+# Using Docker
+
+```
+VOLUME="hyde"
+docker build --tag $VOLUME .
+
+docker run --platform linux/x86_64 --mount type=bind,source="$(pwd)",target=/mnt/host \
+    --tty --interactive \
+    hyde bash
+```
+
 # Parameters and Flags
 
 There are several modes under which the tool can run:

--- a/emitters/yaml_base_emitter.cpp
+++ b/emitters/yaml_base_emitter.cpp
@@ -16,7 +16,7 @@ written permission of Adobe.
 #include <iostream>
 
 // boost
-#include "boost/filesystem.hpp"
+#include "boost/filesystem/fstream.hpp"
 
 // yaml-cpp
 #include "yaml-cpp/yaml.h"

--- a/matchers/utilities.cpp
+++ b/matchers/utilities.cpp
@@ -234,7 +234,7 @@ std::string GetSignature(const ASTContext* n,
         return signature.str();
     }
 
-    if (!isTrailing) {
+    if (!isTrailing && functionT) {
         if (functionT->isConst()) signature << " const";
         if (functionT->isVolatile()) signature << " volatile";
         if (functionT->isRestrict()) signature << " restrict";

--- a/sources/autodetect.cpp
+++ b/sources/autodetect.cpp
@@ -16,6 +16,9 @@ written permission of Adobe.
 #include <array>
 #include <random>
 
+// boost
+#include "boost/filesystem/fstream.hpp"
+
 namespace filesystem = hyde::filesystem;
 
 /**************************************************************************************************/

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -17,6 +17,7 @@ written permission of Adobe.
 
 // boost
 #include "boost/range/irange.hpp"
+#include "boost/filesystem/fstream.hpp"
 
 // clang/llvm
 #include "clang/Frontend/FrontendActions.h"

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -220,6 +220,12 @@ static cl::extrahelp HydeHelp(
 
 /**************************************************************************************************/
 
+bool IsVerbose() {
+    return ToolDiagnostic == ToolDiagnosticVerbose || ToolDiagnostic == ToolDiagnosticVeryVerbose;
+}
+
+/**************************************************************************************************/
+
 std::pair<filesystem::path, hyde::json> load_hyde_config(
     filesystem::path src_file) try {
     bool found{false};
@@ -257,6 +263,14 @@ std::pair<filesystem::path, hyde::json> load_hyde_config(
         directory_walk(src_file);
     }
 
+    if (IsVerbose()) {
+        if (found) {
+            std::cout << "INFO: hyde-config file: " << hyde_config_path.string() << '\n';
+        } else {
+            std::cout << "INFO: hyde-config file: not found\n";
+        }
+    }
+
     return found ?
                std::make_pair(hyde_config_path.parent_path(),
                               hyde::json::parse(filesystem::ifstream(hyde_config_path))) :
@@ -267,7 +281,12 @@ std::pair<filesystem::path, hyde::json> load_hyde_config(
 
 /**************************************************************************************************/
 
-std::vector<std::string> integrate_hyde_config(int argc, const char** argv) {
+struct command_line_args {
+    std::vector<std::string> _hyde;
+    std::vector<std::string> _clang;
+};
+
+command_line_args integrate_hyde_config(int argc, const char** argv) {
     auto cmdline_first = &argv[1];
     auto cmdline_last = &argv[argc];
     auto cmdline_mid = std::find_if(cmdline_first, cmdline_last,
@@ -305,6 +324,8 @@ std::vector<std::string> integrate_hyde_config(int argc, const char** argv) {
     std::tie(config_dir, config) =
         load_hyde_config(cli_hyde_flags.empty() ? "" : cli_hyde_flags.back());
 
+    hyde_flags.push_back(argv[0]);
+
     if (exists(config_dir)) current_path(config_dir);
 
     if (config.count("clang_flags")) {
@@ -333,46 +354,52 @@ std::vector<std::string> integrate_hyde_config(int argc, const char** argv) {
     hyde_flags.insert(hyde_flags.end(), cli_hyde_flags.begin(), cli_hyde_flags.end());
     clang_flags.insert(clang_flags.end(), cli_clang_flags.begin(), cli_clang_flags.end());
 
-    std::vector<std::string> result;
+    hyde_flags.push_back("--");
 
-    result.emplace_back(argv[0]);
+    command_line_args result;
 
-    result.insert(result.end(), hyde_flags.begin(), hyde_flags.end());
-
-    result.emplace_back("--");
-
-    if (!clang_flags.empty()) {
-        // it'd be nice if we could move these into place.
-        result.insert(result.end(), clang_flags.begin(), clang_flags.end());
-    }
+    result._hyde = std::move(hyde_flags);
+    result._clang = std::move(clang_flags);
 
     return result;
 }
 
 /**************************************************************************************************/
 
-std::vector<std::string> source_paths(int argc, const char** argv) {
-    return CommonOptionsParser(argc, argv, MyToolCategory).getSourcePathList();
+namespace {
+
+/**************************************************************************************************/
+
+CommonOptionsParser MakeOptionsParser(int argc, const char** argv) {
+    auto MaybeOptionsParser = CommonOptionsParser::create(argc, argv, MyToolCategory);
+    if (!MaybeOptionsParser) {
+        throw MaybeOptionsParser.takeError();
+    }
+    return std::move(*MaybeOptionsParser);
 }
 
 /**************************************************************************************************/
 
-bool IsVerbose() {
-    return ToolDiagnostic == ToolDiagnosticVerbose || ToolDiagnostic == ToolDiagnosticVeryVerbose;
+} // namespace
+
+/**************************************************************************************************/
+
+std::vector<std::string> source_paths(int argc, const char** argv) {
+    return MakeOptionsParser(argc, argv).getSourcePathList();
 }
 
 /**************************************************************************************************/
 
 int main(int argc, const char** argv) try {
     auto sources = source_paths(argc, argv);
-    std::vector<std::string> args = integrate_hyde_config(argc, argv);
-    int new_argc = static_cast<int>(args.size());
-    std::vector<const char*> new_argv(args.size(), nullptr);
+    command_line_args args = integrate_hyde_config(argc, argv);
+    int new_argc = static_cast<int>(args._hyde.size());
+    std::vector<const char*> new_argv(args._hyde.size(), nullptr);
 
-    std::transform(args.begin(), args.end(), new_argv.begin(),
+    std::transform(args._hyde.begin(), args._hyde.end(), new_argv.begin(),
                    [](const auto& arg) { return arg.c_str(); });
 
-    CommonOptionsParser OptionsParser(new_argc, &new_argv[0], MyToolCategory);
+    CommonOptionsParser OptionsParser(MakeOptionsParser(new_argc, &new_argv[0]));
 
     if (UseSystemClang) {
         AutoResourceDirectory = true;
@@ -385,7 +412,12 @@ int main(int argc, const char** argv) try {
 
     if (IsVerbose()) {
         std::cout << "INFO: Args:\n";
-        for (const auto& arg : args) {
+        std::cout << "INFO:   (hyde)\n";
+        for (const auto& arg : args._hyde) {
+            std::cout << "INFO:     " << arg << '\n';
+        }
+        std::cout << "INFO:   (clang)\n";
+        for (const auto& arg : args._clang) {
             std::cout << "INFO:     " << arg << '\n';
         }
         std::cout << "INFO: Working directory: " << filesystem::current_path().string()
@@ -399,7 +431,6 @@ int main(int argc, const char** argv) try {
         s.insert(i);
     }
     sourcePaths.assign(s.begin(), s.end());
-    ClangTool Tool(OptionsParser.getCompilations(), sourcePaths);
     MatchFinder Finder;
     hyde::processing_options options{sourcePaths, ToolAccessFilter, NamespaceBlacklist, ProcessClassMethods};
 
@@ -422,6 +453,11 @@ int main(int argc, const char** argv) try {
     Finder.addMatcher(hyde::TypedefInfo::GetMatcher(), &typedef_matcher);
 
     clang::tooling::CommandLineArguments arguments;
+
+    // start by appending the command line clang args.
+    for (auto& arg : args._clang) {
+        arguments.emplace_back(std::move(arg));
+    }
 
     if (ToolDiagnostic == ToolDiagnosticVeryVerbose) {
         arguments.emplace_back("-v");
@@ -491,16 +527,34 @@ int main(int argc, const char** argv) try {
         arguments.emplace_back("-resource-dir=" + resource_dir.string());
     }
 
-    //
     // Specify the hyde preprocessor macro
-    // 
     arguments.emplace_back("-DADOBE_TOOL_HYDE=1");
+
+    //
+    // Spin up the tool and run it.
+    //
+
+    ClangTool Tool(OptionsParser.getCompilations(), sourcePaths);
+
+    Tool.appendArgumentsAdjuster([](const CommandLineArguments& arguments, StringRef Filename){
+        return arguments;
+    });
+
+    Tool.appendArgumentsAdjuster(OptionsParser.getArgumentsAdjuster());
 
     Tool.appendArgumentsAdjuster(
         getInsertArgumentAdjuster(arguments, clang::tooling::ArgumentInsertPosition::END));
 
+    Tool.appendArgumentsAdjuster([](const CommandLineArguments& arguments, StringRef Filename){
+        return arguments;
+    });
+
     if (Tool.run(newFrontendActionFactory(&Finder).get()))
         throw std::runtime_error("compilation failed.");
+
+    //
+    // Take the results of the tool and process them.
+    //
 
     hyde::json paths = hyde::json::object();
     paths["src_root"] = YamlSrcDir;
@@ -543,10 +597,16 @@ int main(int argc, const char** argv) try {
         }
     }
 } catch (const std::exception& error) {
-    std::cerr << "Error: " << error.what() << '\n';
+    std::cerr << "Fatal error: " << error.what() << '\n';
+    return EXIT_FAILURE;
+} catch (const Error& error) {
+    std::string description;
+    raw_string_ostream stream(description);
+    stream << error;
+    std::cerr << "Fatal error: " << stream.str() << '\n';
     return EXIT_FAILURE;
 } catch (...) {
-    std::cerr << "Error: unknown\n";
+    std::cerr << "Fatal error: unknown\n";
     return EXIT_FAILURE;
 }
 


### PR DESCRIPTION
## Description

This change builds off of @fosterbrereton's branch `fosterbrereton/llvm13-updates`. 

1. Update CMakeLists.txt to use a more standard brew command to locate `llvm`.
2. Update `.gitignore` to ignore `build*/`
3. Add a few header includes related to a `boost::filesystem` change. 

## Related Issue

## Motivation and Context

Required to build with LLVM 13.

## How Has This Been Tested?

Tested by running a ninja-powered build on my M1 laptop.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
