### PR TITLE
wrapping clang includes to ignore -Werror

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: 🛠️ Build Hyde
         run: |
           cd build
-          xcodebuild -target hyde -configuration Release
+          xcodebuild -quiet -target hyde -configuration Release
       - name: 🗜️ Create archive
         run: |
           cd build/Release

--- a/matchers/class_matcher.cpp
+++ b/matchers/class_matcher.cpp
@@ -15,11 +15,14 @@ written permission of Adobe.
 // stdc++
 #include <iostream>
 
-// clang
+// clang/llvm
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Werror"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
+#pragma clang diagnostic pop
 
 // application
 #include "json.hpp"

--- a/matchers/class_matcher.hpp
+++ b/matchers/class_matcher.hpp
@@ -11,9 +11,12 @@ written permission of Adobe.
 
 #pragma once
 
-// clang
+// clang/llvm
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Werror"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
+#pragma clang diagnostic pop
 
 // application
 #include "json.hpp"

--- a/matchers/enum_matcher.cpp
+++ b/matchers/enum_matcher.cpp
@@ -15,10 +15,13 @@ written permission of Adobe.
 // stdc++
 #include <iostream>
 
-// clang
+// clang/llvm
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Werror"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
+#pragma clang diagnostic pop
 
 // application
 #include "json.hpp"

--- a/matchers/enum_matcher.hpp
+++ b/matchers/enum_matcher.hpp
@@ -11,9 +11,12 @@ written permission of Adobe.
 
 #pragma once
 
-// clang
+// clang/llvm
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Werror"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
+#pragma clang diagnostic pop
 
 // application
 #include "json.hpp"

--- a/matchers/function_matcher.cpp
+++ b/matchers/function_matcher.cpp
@@ -15,11 +15,14 @@ written permission of Adobe.
 // stdc++
 #include <iostream>
 
-// clang
+// clang/llvm
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Werror"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Lex/Lexer.h"
+#pragma clang diagnostic pop
 
 // application
 #include "json.hpp"

--- a/matchers/function_matcher.hpp
+++ b/matchers/function_matcher.hpp
@@ -11,9 +11,12 @@ written permission of Adobe.
 
 #pragma once
 
-// clang
+// clang/llvm
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Werror"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
+#pragma clang diagnostic pop
 
 // application
 #include "json.hpp"

--- a/matchers/namespace_matcher.cpp
+++ b/matchers/namespace_matcher.cpp
@@ -15,10 +15,13 @@ written permission of Adobe.
 // stdc++
 #include <iostream>
 
-// clang
+// clang/llvm
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Werror"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
+#pragma clang diagnostic pop
 
 // application
 #include "json.hpp"

--- a/matchers/namespace_matcher.hpp
+++ b/matchers/namespace_matcher.hpp
@@ -11,9 +11,12 @@ written permission of Adobe.
 
 #pragma once
 
-// clang
+// clang/llvm
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Werror"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
+#pragma clang diagnostic pop
 
 // application
 #include "json.hpp"

--- a/matchers/typealias_matcher.cpp
+++ b/matchers/typealias_matcher.cpp
@@ -15,10 +15,13 @@ written permission of Adobe.
 // stdc++
 #include <iostream>
 
-// clang
+// clang/llvm
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Werror"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
+#pragma clang diagnostic pop
 
 // application
 #include "json.hpp"

--- a/matchers/typealias_matcher.hpp
+++ b/matchers/typealias_matcher.hpp
@@ -11,9 +11,12 @@ written permission of Adobe.
 
 #pragma once
 
-// clang
+// clang/llvm
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Werror"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
+#pragma clang diagnostic pop
 
 // application
 #include "json.hpp"

--- a/matchers/typedef_matcher.cpp
+++ b/matchers/typedef_matcher.cpp
@@ -15,10 +15,13 @@ written permission of Adobe.
 // stdc++
 #include <iostream>
 
-// clang
+// clang/llvm
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Werror"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
+#pragma clang diagnostic pop
 
 // application
 #include "json.hpp"

--- a/matchers/typedef_matcher.hpp
+++ b/matchers/typedef_matcher.hpp
@@ -11,9 +11,12 @@ written permission of Adobe.
 
 #pragma once
 
-// clang
+// clang/llvm
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Werror"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
+#pragma clang diagnostic pop
 
 // application
 #include "json.hpp"

--- a/matchers/utilities.cpp
+++ b/matchers/utilities.cpp
@@ -16,7 +16,9 @@ written permission of Adobe.
 #include <iostream>
 #include <sstream>
 
-// clang
+// clang/llvm
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Werror"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Type.h"
@@ -24,6 +26,7 @@ written permission of Adobe.
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Lex/Lexer.h"
 #include "llvm/ADT/ArrayRef.h"
+#pragma clang diagnostic pop
 
 // application
 #include "json.hpp"

--- a/matchers/utilities.hpp
+++ b/matchers/utilities.hpp
@@ -14,12 +14,15 @@ written permission of Adobe.
 // stdc++
 #include <optional>
 
-// clang
+// clang/llvm
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Werror"
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "llvm/ADT/ArrayRef.h"
+#pragma clang diagnostic pop
 
 // application
 #include "json.hpp"

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -18,10 +18,13 @@ written permission of Adobe.
 #include <sstream>
 
 // clang/llvm
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Werror"
 #include "clang/Frontend/FrontendActions.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/Tooling.h"
 #include "llvm/Support/CommandLine.h"
+#pragma clang diagnostic pop
 
 // application
 #include "autodetect.hpp"


### PR DESCRIPTION
This is in an effort to get the v0.1.4 tag building on both mac and linux.