### PR TITLE
Adding all `hyde` values under a top-level `hyde` YAML key

### DIFF
--- a/emitters/yaml_base_emitter_fwd.hpp
+++ b/emitters/yaml_base_emitter_fwd.hpp
@@ -55,13 +55,9 @@ static inline bool is_tag(const std::string& s) {
 /**************************************************************************************************/
 
 struct emit_options {
-    attribute_category _tested_by;
-    bool _ignore_extraneous_files;
-    
-    emit_options() :
-        _tested_by(attribute_category::disabled),
-        _ignore_extraneous_files(false)
-    {}
+    attribute_category _tested_by{attribute_category::disabled};
+    bool _ignore_extraneous_files{false};
+    bool _fixup_hyde_subfield{false};
 };
 
 /**************************************************************************************************/

--- a/emitters/yaml_class_emitter.cpp
+++ b/emitters/yaml_class_emitter.cpp
@@ -66,24 +66,24 @@ bool yaml_class_emitter::do_merge(const std::string& filepath,
 
 bool yaml_class_emitter::emit(const json& j, json& out_emitted) {
     json node = base_emitter_node("class", j["name"], "class");
-    node["defined_in_file"] = defined_in_file(j["defined_in_file"], _src_root);
+    node["hyde"]["defined_in_file"] = defined_in_file(j["defined_in_file"], _src_root);
     maybe_annotate(j, node);
 
     std::string declaration = format_template_parameters(j, true) + '\n' +
                               static_cast<const std::string&>(j["kind"]) + " " +
                               static_cast<const std::string&>(j["qualified_name"]) + ";";
-    node["declaration"] = std::move(declaration);
+    node["hyde"]["declaration"] = std::move(declaration);
 
     for (const auto& ns : j["namespaces"])
-        node["namespace"].push_back(static_cast<const std::string&>(ns));
+        node["hyde"]["namespace"].push_back(static_cast<const std::string&>(ns));
 
-    if (j.count("ctor")) node["ctor"] = static_cast<const std::string&>(j["ctor"]);
-    if (j.count("dtor")) node["dtor"] = static_cast<const std::string&>(j["dtor"]);
+    if (j.count("ctor")) node["hyde"]["ctor"] = static_cast<const std::string&>(j["ctor"]);
+    if (j.count("dtor")) node["hyde"]["dtor"] = static_cast<const std::string&>(j["dtor"]);
 
     if (j.count("fields")) {
         for (const auto& field : j["fields"]) {
             const std::string& key = field["name"];
-            auto& field_node = node["fields"][key];
+            auto& field_node = node["hyde"]["fields"][key];
             field_node["type"] = static_cast<const std::string&>(field["type"]);
             field_node["description"] = tag_value_missing_k;
             maybe_annotate(field, field_node);

--- a/emitters/yaml_enum_emitter.cpp
+++ b/emitters/yaml_enum_emitter.cpp
@@ -56,13 +56,13 @@ bool yaml_enum_emitter::emit(const json& j, json& out_emitted) {
     if (j["values"].empty()) return true;
 
     json node = base_emitter_node("enumeration", j["name"], "enumeration");
-    node["defined_in_file"] = defined_in_file(j["defined_in_file"], _src_root);
+    node["hyde"]["defined_in_file"] = defined_in_file(j["defined_in_file"], _src_root);
     maybe_annotate(j, node);
     
     std::string filename;
     for (const auto& ns : j["namespaces"]) {
         const std::string& namespace_str = ns;
-        node["namespace"].push_back(namespace_str);
+        node["hyde"]["namespace"].push_back(namespace_str);
         filename += namespace_str + "::";
     }
     filename = filename_filter(std::move(filename) + name) + ".md";
@@ -71,7 +71,7 @@ bool yaml_enum_emitter::emit(const json& j, json& out_emitted) {
         json cur_value;
         cur_value["name"] = value["name"];
         cur_value["description"] = tag_value_missing_k;
-        node["values"].push_back(std::move(cur_value));
+        node["hyde"]["values"].push_back(std::move(cur_value));
     }
 
     return reconcile(std::move(node), _dst_root, dst_path(j) / filename, out_emitted);

--- a/emitters/yaml_function_emitter.cpp
+++ b/emitters/yaml_function_emitter.cpp
@@ -122,17 +122,17 @@ bool yaml_function_emitter::emit(const json& jsn, json& out_emitted) {
 
     json node = base_emitter_node(_as_methods ? "method" : "function", name,
                                   _as_methods ? "method" : "function");
-    node["defined_in_file"] = defined_path;
+    node["hyde"]["defined_in_file"] = defined_path;
     
     if (!_as_methods && jsn.size() > 0) {
         // All overloads will have the same namespace
         for (const auto& ns : jsn.front()["namespaces"])
-            node["namespace"].push_back(static_cast<const std::string&>(ns));
+            node["hyde"]["namespace"].push_back(static_cast<const std::string&>(ns));
     }
     
-    node["overloads"] = std::move(overloads);
-    if (is_ctor) node["is_ctor"] = true;
-    if (is_dtor) node["is_dtor"] = true;
+    node["hyde"]["overloads"] = std::move(overloads);
+    if (is_ctor) node["hyde"]["is_ctor"] = true;
+    if (is_dtor) node["hyde"]["is_dtor"] = true;
 
     return reconcile(std::move(node), _dst_root, dst / (filename + ".md"), out_emitted);
 }

--- a/emitters/yaml_library_emitter.cpp
+++ b/emitters/yaml_library_emitter.cpp
@@ -39,10 +39,10 @@ bool yaml_library_emitter::do_merge(const std::string& filepath,
 
 bool yaml_library_emitter::emit(const json&, json& out_emitted) {
     json node = base_emitter_node("library", tag_value_missing_k, "library");
-    node["library-type"] = "library";
-    node["icon"] = tag_value_missing_k;
-    node["tab"] = tag_value_missing_k;
-    node["short_title"] = tag_value_optional_k;
+    node["hyde"]["library-type"] = "library";
+    node["hyde"]["icon"] = tag_value_missing_k;
+    node["hyde"]["tab"] = tag_value_missing_k;
+    node["hyde"]["short_title"] = tag_value_optional_k;
 
     return reconcile(std::move(node), _dst_root, _dst_root / index_filename_k, out_emitted);
 }

--- a/emitters/yaml_sourcefile_emitter.cpp
+++ b/emitters/yaml_sourcefile_emitter.cpp
@@ -38,7 +38,7 @@ bool yaml_sourcefile_emitter::do_merge(const std::string& filepath,
 bool yaml_sourcefile_emitter::emit(const json& j, json& out_emitted) {
     const auto sub_path = subcomponent(static_cast<const std::string&>(j["paths"]["src_path"]), _src_root);
     json node = base_emitter_node("library", sub_path.string(), "sourcefile");
-    node["library-type"] = "sourcefile";
+    node["hyde"]["library-type"] = "sourcefile";
 
     insert_typedefs(j, node);
 

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -127,6 +127,12 @@ static cl::opt<bool> EmitJson(
     cl::cat(MyToolCategory),
     cl::ValueDisallowed);
 
+static cl::opt<bool> FixupHydeSubfield(
+    "fixup-hyde-subfield",
+    cl::desc("Fix-up preexisting documentation; move all fields except `layout` and `title` into a `hyde` subfield. `hyde-update` mode only."),
+    cl::cat(MyToolCategory),
+    cl::ValueDisallowed);
+
 static cl::opt<hyde::attribute_category> TestedBy(
     "hyde-tested-by",
     cl::values(
@@ -595,7 +601,8 @@ int main(int argc, const char** argv) try {
         hyde::emit_options emit_options;
         emit_options._tested_by = TestedBy;
         emit_options._ignore_extraneous_files = IgnoreExtraneousFiles;
-        
+        emit_options._fixup_hyde_subfield = FixupHydeSubfield;
+
         auto out_emitted = hyde::json::object();
         output_yaml(std::move(result), std::move(src_root), std::move(dst_root), out_emitted,
                     ToolMode == ToolModeYAMLValidate ? hyde::yaml_mode::validate :


### PR DESCRIPTION
This puts all hyde-specific flags under a top-level `hyde` field in YAML output.

This also comes with a new flag, `--fixup-hyde-subfield`, that when used during a `--hyde-update` will pull _all_ top-level fields except `title` and `layout` under a `hyde` subfield.

Fixes issue #75.