### PR TITLE
Fixing docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,17 +24,12 @@ RUN apt-get -y install build-essential
 # directory with
 # `hyde ./test.hpp -- -x c++ -print-resource-dir`
 
+# FROM base AS full
+
 ENV LLVM_VERSION=15
 
 RUN apt-get -y install clang-${LLVM_VERSION}
-
-# The above doesn't setup libc++ header paths correctly. Currently LLVM-15
-# doesn't install with llvm.sh in docker. So we install LLVM-16 just for
-# the libc++ config!
-
-RUN wget https://apt.llvm.org/llvm.sh
-RUN chmod +x llvm.sh
-RUN ./llvm.sh 16 all
+RUN apt-get -y install libc++-${LLVM_VERSION}-dev
 
 # set clang ${LLVM_VERSION} to be the version of clang we use when clang/clang++ is invoked
 RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 100
@@ -64,3 +59,7 @@ RUN cp ./build/hyde /usr/bin
 # RUN apt-get -y install clang-15
 
 CMD ["./generate_test_files.sh"]
+
+# Experimenting with publishing the container and linking it to the hyde repo:
+
+LABEL org.opencontainers.image.source=https://github.com/adobe/hyde

--- a/README.md
+++ b/README.md
@@ -39,9 +39,21 @@
 
 LLVM/Clang are declared as a dependency in the project's `CMakeLists.txt` file, and will be downloaded and made available to the project automatically.
 
-# Using Docker
+# How to run from Docker
 
-You may need to increase your docker resources to build the image.
+```sh
+docker pull ghcr.io/adobe/hyde:latest
+
+docker run --platform linux/x86_64 --mount type=bind,source="$(pwd)",target=/mnt/host \
+    --tty --interactive \
+    ghcr.io/adobe/hyde:latest bash
+```
+
+You can then run the examples as below, except don't prefix `hyde` with `./`.
+
+# Building the Docker image
+
+You may need to increase your docker resources to build the image. (2.0.1 successfully built with 16GB RAM and 4GB swap)
 
 ```sh
 docker build --tag hyde .
@@ -50,6 +62,20 @@ docker run --platform linux/x86_64 --mount type=bind,source="$(pwd)",target=/mnt
     --tty --interactive \
     hyde bash
 ```
+
+# Publishing the docker image (requires write access to the `adobe` GitHub organization)
+
+Instructions for publishing a GitHub package can be found [here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
+Instructions for associating the with the `adobe/hyde` repository can be found [here](https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package#connecting-a-repository-to-a-container-image-using-the-command-line).
+
+```sh
+VERSION=2.0.1
+docker tag hyde ghcr.io/adobe/hyde:$VERSION
+docker tag hyde ghcr.io/adobe/hyde:latest
+docker push ghcr.io/adobe/hyde:$VERSION
+docker push ghcr.io/adobe/hyde:latest
+```
+
 
 # Parameters and Flags
 

--- a/sources/autodetect.cpp
+++ b/sources/autodetect.cpp
@@ -13,9 +13,16 @@ written permission of Adobe.
 #include "autodetect.hpp"
 
 // stdc++
+#include <algorithm>
 #include <array>
-#include <random>
+#include <cstdio>
 #include <fstream>
+#include <iterator>
+#include <memory>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
 
 /**************************************************************************************************/
 
@@ -28,9 +35,11 @@ std::vector<std::string> split(const char* p, std::size_t n) {
     std::vector<std::string> result;
 
     while (p != end) {
-        while (p != end && *p == '\n') ++p; // eat newlines
+        while (p != end && *p == '\n')
+            ++p; // eat newlines
         auto begin = p;
-        while (p != end && *p != '\n') ++p; // eat non-newlines
+        while (p != end && *p != '\n')
+            ++p; // eat non-newlines
         result.emplace_back(begin, p);
     }
 
@@ -78,22 +87,26 @@ std::string trim_back(std::string s) {
 
 /**************************************************************************************************/
 
-std::string chomp(std::string src) {
-    return trim_back(trim_front(std::move(src)));
-}
+std::string chomp(std::string src) { return trim_back(trim_front(std::move(src))); }
 
 /**************************************************************************************************/
 
 std::string exec(const char* cmd) {
-    std::array<char, 128> buffer;
-    std::string result;
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), pclose);
+    struct pclose_t {
+        void operator()(std::FILE* p) const { (void)pclose(p); }
+    };
+    std::unique_ptr<std::FILE, pclose_t> pipe{popen(cmd, "r")};
+
     if (!pipe) {
         throw std::runtime_error("popen() failed!");
     }
+
+    std::array<char, 128> buffer;
+    std::string result;
     while (fgets(buffer.data(), buffer.size(), pipe.get())) {
         result += buffer.data();
     }
+
     return chomp(std::move(result));
 }
 
@@ -105,7 +118,8 @@ std::vector<std::filesystem::path> autodetect_include_paths() {
     auto temp_dir = std::filesystem::temp_directory_path();
     auto temp_out = (temp_dir / ("hyde_" + v + ".tmp")).string();
     auto temp_a_out = (temp_dir / ("deleteme_" + v)).string();
-    auto command = "echo \"int main() { }\" | clang++ -x c++ -v -o " + temp_a_out + " - 2> " + temp_out;
+    auto command =
+        "echo \"int main() { }\" | clang++ -x c++ -v -o " + temp_a_out + " - 2> " + temp_out;
 
     auto command_result = std::system(command.c_str());
     (void)command_result; // TODO: handle me
@@ -119,14 +133,14 @@ std::vector<std::filesystem::path> autodetect_include_paths() {
 
     if (paths_begin != end(lines) && paths_end != end(lines)) {
         lines.erase(paths_end, end(lines));
-        lines.erase(begin(lines), next(paths_begin));
+        lines.erase(begin(lines), std::next(paths_begin));
 
         // lines.erase(std::remove_if(begin(lines), end(lines), [](auto& s){
         //     return s.find(".sdk/") != std::string::npos;
         // }), end(lines));
 
         // Some of the paths contain cruft at the end. Filter those out, too.
-        std::transform(begin(lines), end(lines), std::back_inserter(result), [](auto s){
+        std::transform(begin(lines), end(lines), std::back_inserter(result), [](auto s) {
             static const std::string needle_k{" (framework directory)"};
             auto needle_pos = s.find(needle_k);
             if (needle_pos != std::string::npos) {


### PR DESCRIPTION
## Description

- Speedup and simplify docker build
- Fix compiler errors when building with clang-15
- Update readme on building with docker
- Minor reformatting (using existing `.clang-format` file)

## Related Issue

I'm pushing a 2.0.1 Hyde docker image to an associated package (I've never done an associated package... so we'll see if it works!)

After the commit happens, I'll review the outstanding issues and comment (I know there is one on using Hyde on Windows, this is a good solution).

## Motivation and Context

The docker image wasn't building; when it was last built, it was a hack. I needed it working to update the stlab docs.

## How Has This Been Tested?

I'm using this to update stlab docs.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
