### PR TITLE
Adding `transcribe` mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ message(STATUS "INFO: Setting up LLVM...")
 FetchContent_Declare(
     llvm
     GIT_REPOSITORY https://github.com/llvm/llvm-project.git
-    GIT_TAG 7cbf1a2591520c2491aa35339f227775f4d3adf6 # llvmorg-16.0.6
+    GIT_TAG 3b5b5c1ec4a3095ab096dd780e84d7ab81f3d7ff # llvmorg-18.1.8
     GIT_SHALLOW TRUE
     GIT_PROGRESS TRUE
     SOURCE_SUBDIR llvm
@@ -39,7 +39,7 @@ FetchContent_Declare(
 FetchContent_Declare(
     diff
     GIT_REPOSITORY https://github.com/fosterbrereton/diff.git
-    GIT_TAG 702efcba1ab81f6a86a196a941c2393125347386
+    GIT_TAG 2ba1687a30de266416caa141f8be408e72843be0
     GIT_SHALLOW TRUE
     GIT_PROGRESS TRUE
     SOURCE_SUBDIR diff

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,19 @@ message(STATUS "INFO: Setting up LLVM...")
 FetchContent_Declare(
     llvm
     GIT_REPOSITORY https://github.com/llvm/llvm-project.git
-    GIT_TAG 3b5b5c1ec4a3095ab096dd780e84d7ab81f3d7ff # llvmorg-18.1.8
+    GIT_TAG 7cbf1a2591520c2491aa35339f227775f4d3adf6 # llvmorg-16.0.6
     GIT_SHALLOW TRUE
     GIT_PROGRESS TRUE
     SOURCE_SUBDIR llvm
+)
+
+FetchContent_Declare(
+    diff
+    GIT_REPOSITORY https://github.com/fosterbrereton/diff.git
+    GIT_TAG 702efcba1ab81f6a86a196a941c2393125347386
+    GIT_SHALLOW TRUE
+    GIT_PROGRESS TRUE
+    SOURCE_SUBDIR diff
 )
 
 set(LLVM_ENABLE_PROJECTS "clang")
@@ -41,6 +50,7 @@ set(LLVM_TARGETS_TO_BUILD "X86;AArch64")
 set(LLVM_ENABLE_ZSTD OFF)
 
 FetchContent_MakeAvailable(llvm)
+FetchContent_MakeAvailable(diff)
 
 message(STATUS "INFO: LLVM source dir: ${llvm_SOURCE_DIR}")
 message(STATUS "INFO: LLVM binary dir: ${llvm_BINARY_DIR}")
@@ -127,6 +137,7 @@ target_include_directories(hyde
         ${llvm_BINARY_DIR}/tools/clang/include
         ${llvm_SOURCE_DIR}/llvm/include
         ${llvm_BINARY_DIR}/include
+        ${diff_SOURCE_DIR}/include
 )
 
 target_compile_options(hyde

--- a/emitters/yaml_base_emitter.cpp
+++ b/emitters/yaml_base_emitter.cpp
@@ -19,9 +19,6 @@ written permission of Adobe.
 // yaml-cpp
 #include "yaml-cpp/yaml.h"
 
-// diff
-#include "diff/myers.hpp"
-
 // application
 #include "emitters/yaml_base_emitter_fwd.hpp"
 #include "json.hpp"
@@ -1620,26 +1617,6 @@ std::string yaml_base_emitter::filename_filter(std::string f) {
                   [&](const auto& c) { result += uri_equivalent[static_cast<int>(c)]; });
 
     return result;
-}
-
-/**************************************************************************************************/
-
-std::size_t diff_score(std::string_view src, std::string_view dst) {
-    const myers::patch patch = myers::diff(src, dst);
-    std::size_t score = 0;
-
-    for (const auto& c : patch) {
-        switch (c.operation) {
-            case myers::operation::cpy:
-                break;
-            case myers::operation::del:
-            case myers::operation::ins: {
-                score += c.text.size();
-            } break;
-        }
-    }
-
-    return score;
 }
 
 /**************************************************************************************************/

--- a/emitters/yaml_base_emitter.cpp
+++ b/emitters/yaml_base_emitter.cpp
@@ -19,6 +19,9 @@ written permission of Adobe.
 // yaml-cpp
 #include "yaml-cpp/yaml.h"
 
+// diff
+#include "diff/myers.hpp"
+
 // application
 #include "emitters/yaml_base_emitter_fwd.hpp"
 #include "json.hpp"
@@ -392,6 +395,7 @@ void yaml_base_emitter::check_notify(const std::string& filepath,
             std::cerr << filepath << "@" << escaped_nodepath << "['" << escaped_key
                       << "']: " << validate_message << "\n";
         } break;
+        case yaml_mode::transcribe:
         case yaml_mode::update: {
             std::cout << filepath << "@" << escaped_nodepath << "['" << escaped_key
                       << "']: " << update_message << "\n";
@@ -980,6 +984,96 @@ bool yaml_base_emitter::check_object_array(const std::string& filepath,
 
 /**************************************************************************************************/
 
+std::vector<std::string> object_keys(const json& j) {
+    std::vector<std::string> result;
+
+    for (auto iter{j.begin()}, last{j.end()}; iter != last; ++iter) {
+        result.push_back(static_cast<const std::string&>(iter.key()));
+    }
+
+    return result;
+}
+
+template <class T>
+inline void move_append(T& dst, T&& src) {
+    dst.insert(dst.end(), std::make_move_iterator(src.begin()), std::make_move_iterator(src.end()));
+}
+
+struct transcribe_pair {
+    std::string src;
+    std::string dst;
+};
+
+using transcribe_pairs = std::vector<transcribe_pair>;
+
+// This is O(N^2), where N is the size of both `src` and `dst`. Therefore transcription
+// should only be run when it is shown to be necessary. At the same time, if your code base
+// has enough overrides to really slow this algorithm down, hyde's performance is the least
+// of your concerns.
+transcribe_pairs derive_transcribe_pairs(const json& src, const json& dst) {
+    std::vector<std::string> src_keys = object_keys(src);
+    std::vector<std::string> dst_keys = object_keys(dst);
+
+    if (src_keys.size() != dst_keys.size()) {
+        std::cerr << "WARNING: transcription key count mismatch\n";
+    }
+
+    const auto score = [](const myers::patch& p) {
+        std::size_t score = 0;
+
+        for (const auto& c : p) {
+            switch (c.operation) {
+                case myers::operation::cpy:
+                    break;
+                case myers::operation::del:
+                case myers::operation::ins: {
+                    score += c.text.size();
+                } break;
+            }
+        }
+
+        return score;
+    };
+
+    transcribe_pairs result;
+
+    while (!src_keys.empty()) {
+        transcribe_pair cur_pair;
+
+        // pop a key off the old name set
+        cur_pair.src = std::move(src_keys.back());
+        src_keys.pop_back();
+
+        // find the best match of the dst keys to the src key
+        std::size_t best_match = std::numeric_limits<std::size_t>::max();
+        std::size_t best_index = 0;
+        for (std::size_t i = 0; i < dst_keys.size(); ++i) {
+            // generate the meyers diff of the src key and the candidate dst
+            const myers::patch patch = myers::diff(cur_pair.src, dst_keys[i]);
+            std::size_t cur_match = score(patch);
+
+            if (cur_match > best_match) {
+                continue;
+            }
+
+            // if this dst candidate is better than what we've seen, remember that.
+            best_match = cur_match;
+            best_index = i;
+        }
+
+        // pair the best match dst and src keys and remove dst
+        cur_pair.dst = std::move(dst_keys[best_index]);
+        dst_keys.erase(dst_keys.begin() + best_index);
+
+        // save off the pair and repeat
+        result.emplace_back(std::move(cur_pair));
+    }
+
+    return result;
+}
+
+/**************************************************************************************************/
+
 bool yaml_base_emitter::check_map(const std::string& filepath,
                                   const json& have_node,
                                   const json& expected_node,
@@ -1013,38 +1107,68 @@ bool yaml_base_emitter::check_map(const std::string& filepath,
     }
 
     const json& have = have_node[key];
-
-    std::vector<std::string> keys;
-
-    for (auto iter{have.begin()}, last{have.end()}; iter != last; ++iter) {
-        keys.push_back(static_cast<const std::string&>(iter.key()));
-    }
-    for (auto iter{expected.begin()}, last{expected.end()}; iter != last; ++iter) {
-        keys.push_back(static_cast<const std::string&>(iter.key()));
-    }
-
-    std::sort(keys.begin(), keys.end());
-    keys.erase(std::unique(keys.begin(), keys.end()), keys.end());
-
     bool failure{false};
-
     json result_map;
-    for (const auto& subkey : keys) {
-        std::string curnodepath = nodepath + "['" + subkey + "']";
 
-        if (!expected.count(subkey)) {
-            // Issue #75: only remove non-root keys to allow non-hyde YAML into the file.
-            if (!at_root) {
-                notify("extraneous map key: `" + subkey + "`", "map key removed: `" + subkey + "`");
+    if (key == "overloads" && _mode == yaml_mode::transcribe) {
+        /*
+        It is common during the upgrade from one version of hyde to another that the underlying
+        clang tooling will output different symbol names for a given symbol (e.g., a namespace
+        may get removed or added.) Although the symbol is unchanged, because its `expected` name
+        differs from the `have` name, hyde will consider the symbols different, remove the old name
+        and insert the new one. This wipes out any previous documentation under the old name that
+        should have been migrated to the new name.
+
+        The solution here is very specialized. For the "overloads" key only, we gather the name
+        of each overload in both the `have` and `expected` set. We then pair them up according
+        to how well they match to one another (using the Meyers' string diff algorithm; two strings
+        with less "patchwork" between them are considered a better match). Ideally this results in
+        key pairs that represent the same symbol, just with different names. Then we call the
+        `proc` with `have[old_name]` and `expected[new_name]` which will migrate any documentation
+        from the old name to the new.
+
+        This capability assumes the overload count of both `have` and `expected` are the same.
+        If any new functions are created or removed between upgrades in the clang driver (e.g.,
+        a new compiler-generated routine is created and documented) that will have to be managed
+        manually. Assuming the count is the same, it also assumes there is a 1:1 mapping from the
+        set of old names to the set of new names. This implies the transcription mode should be
+        done as a separate step from an update. In other words, a transcription assumes the
+        documentation is actually the same between the `have` and `expected` sets, it is _just the
+        overload names_ that have changed, so map the old-named documentation to the new-named
+        documentation as reasonably as possible.
+        */
+        for (const auto& pair : derive_transcribe_pairs(have, expected)) {
+            const std::string curnodepath = nodepath + "['" + pair.dst + "']";
+            failure |= proc(filepath, have[pair.src], expected[pair.dst], curnodepath,
+                            result_map[pair.dst]);
+        }
+    } else {
+        std::vector<std::string> keys;
+
+        move_append(keys, object_keys(have));
+        move_append(keys, object_keys(expected));
+
+        std::sort(keys.begin(), keys.end());
+        keys.erase(std::unique(keys.begin(), keys.end()), keys.end());
+
+        for (const auto& subkey : keys) {
+            const std::string curnodepath = nodepath + "['" + subkey + "']";
+
+            if (!expected.count(subkey)) {
+                // Issue #75: only remove non-root keys to allow non-hyde YAML into the file.
+                if (!at_root) {
+                    notify("extraneous map key: `" + subkey + "`",
+                           "map key removed: `" + subkey + "`");
+                    failure = true;
+                }
+            } else if (!have.count(subkey)) {
+                notify("map key missing: `" + subkey + "`", "map key inserted: `" + subkey + "`");
+                result_map[subkey] = expected[subkey];
                 failure = true;
+            } else {
+                failure |=
+                    proc(filepath, have[subkey], expected[subkey], curnodepath, result_map[subkey]);
             }
-        } else if (!have.count(subkey)) {
-            notify("map key missing: `" + subkey + "`", "map key inserted: `" + subkey + "`");
-            result_map[subkey] = expected[subkey];
-            failure = true;
-        } else {
-            failure |=
-                proc(filepath, have[subkey], expected[subkey], curnodepath, result_map[subkey]);
         }
     }
 
@@ -1264,7 +1388,7 @@ documentation parse_documentation(const std::filesystem::path& path, bool fixup_
     const auto front_matter_end = contents_end + front_matter_end_k.size();
     std::string yaml_src = have_contents.substr(0, front_matter_end);
     have_contents.erase(0, front_matter_end);
-    
+
     result._remainder = std::move(have_contents);
     result._json = yaml_to_json(load_yaml(path));
 
@@ -1342,6 +1466,7 @@ bool yaml_base_emitter::reconcile(json expected,
             case hyde::yaml_mode::validate: {
                 // do nothing
             } break;
+            case hyde::yaml_mode::transcribe:
             case hyde::yaml_mode::update: {
                 failure = write_documentation({std::move(merged), std::move(remainder)}, path);
             } break;
@@ -1354,6 +1479,7 @@ bool yaml_base_emitter::reconcile(json expected,
                 std::cerr << relative_path << ": required file does not exist\n";
                 failure = true;
             } break;
+            case hyde::yaml_mode::transcribe:
             case hyde::yaml_mode::update: {
                 // Add update. No remainder yet, as above.
                 // REVISIT: Refactor all this into a call to write_documentation,

--- a/emitters/yaml_base_emitter.hpp
+++ b/emitters/yaml_base_emitter.hpp
@@ -245,11 +245,6 @@ std::filesystem::path yaml_base_emitter::dst_path_append(std::filesystem::path p
 }
 
 /**************************************************************************************************/
-/// compute a value (based on a diff algorithm) to determine roughly how much two strings are like
-/// each other. The lower the value the better, with 0 meaning the two strings are identical.
-std::size_t diff_score(std::string_view src, std::string_view dst);
-
-/**************************************************************************************************/
 
 } // namespace hyde
 

--- a/emitters/yaml_base_emitter.hpp
+++ b/emitters/yaml_base_emitter.hpp
@@ -245,6 +245,11 @@ std::filesystem::path yaml_base_emitter::dst_path_append(std::filesystem::path p
 }
 
 /**************************************************************************************************/
+/// compute a value (based on a diff algorithm) to determine roughly how much two strings are like
+/// each other. The lower the value the better, with 0 meaning the two strings are identical.
+std::size_t diff_score(std::string_view src, std::string_view dst);
+
+/**************************************************************************************************/
 
 } // namespace hyde
 

--- a/emitters/yaml_class_emitter.cpp
+++ b/emitters/yaml_class_emitter.cpp
@@ -17,6 +17,7 @@ written permission of Adobe.
 
 // application
 #include "emitters/yaml_function_emitter.hpp"
+#include "matchers/utilities.hpp"
 
 /**************************************************************************************************/
 
@@ -70,6 +71,60 @@ bool yaml_class_emitter::do_merge(const std::string& filepath,
 
 /**************************************************************************************************/
 
+std::filesystem::path derive_transcription_src_path(const std::filesystem::path& dst,
+                                                    const std::string& title) {
+    const auto parent = dst.parent_path();
+    std::size_t best_match = std::numeric_limits<std::size_t>::max();
+    std::filesystem::path result;
+    const std::string& current_version = hyde_version();
+
+    for (const auto& entry : std::filesystem::directory_iterator(dst.parent_path())) {
+        const auto sibling = entry.path();
+        if (!is_directory(sibling)) continue;
+        const auto index_path = sibling / index_filename_k;
+
+        if (!exists(index_path)) {
+            std::cerr << "WARN: expected " << index_path.string() << " but did not find one\n";
+            continue;
+        }
+
+        const auto have_docs = parse_documentation(index_path, true);
+
+        if (have_docs._error) {
+            std::cerr << "WARN: expected " << index_path.string() << " to have docs\n";
+            continue;
+        }
+
+        const auto& have = have_docs._json;
+
+        if (have.count("version")) {
+            // Transcription is when we're going from a previous version of hyde to this one.
+            // So if the versions match, this is a directory that has already been transcribed.
+            // (Transcribing from a newer version of hyde docs to older ones isn't supported.)
+            if (static_cast<const std::string&>(have["version"]) == current_version) {
+                continue;
+            }
+        }
+
+        // REVISIT (fosterbrereton): Are these titles editable? Would
+        // users muck with them and thus break this algorithm?
+        const std::string& have_title = static_cast<const std::string&>(have["title"]);
+
+        // score going from what we have to what this version computed.
+        const auto match = diff_score(have_title, title);
+        if (match > best_match) {
+            continue;
+        }
+
+        best_match = match;
+        result = sibling;
+    }
+
+    return result;
+}
+
+/**************************************************************************************************/
+
 bool yaml_class_emitter::emit(const json& j, json& out_emitted, const json& inherited) {
     json node = base_emitter_node("class", j["name"], "class", has_json_flag(j, "implicit"));
     node["hyde"]["defined_in_file"] = defined_in_file(j["defined_in_file"], _src_root);
@@ -107,6 +162,20 @@ bool yaml_class_emitter::emit(const json& j, json& out_emitted, const json& inhe
     insert_typedefs(j, node, inherited);
 
     auto dst = dst_path(j, static_cast<const std::string&>(j["name"]));
+
+    if (_mode == yaml_mode::transcribe && !exists(dst)) {
+        // In this case the symbol name has changed, which has caused a change to the directory name
+        // we are now trying to load and reconcile with what we've created. In this case, we can
+        // assume the "shape" of the documentation is the same, which means that within the parent
+        // folder of `dst` is the actual source folder that holds the old documentation, just under
+        // a different name. So, iterate the list of directories in the parent, find their
+        // `index.md` files, load the `title` of each, and find the best-fit against the `title`
+        // stored in `node`. Once we have found that best fit directory, rename it to the `dst`
+        // path, and then we can continue. It's a lot of legwork, but the only way I can think of
+        // to reconcile a previous version name for a symbol with a new one.
+
+        std::filesystem::rename(derive_transcription_src_path(dst, node["title"]), dst);
+    }
 
     bool failure =
         reconcile(std::move(node), _dst_root, std::move(dst) / index_filename_k, out_emitted);

--- a/emitters/yaml_function_emitter.cpp
+++ b/emitters/yaml_function_emitter.cpp
@@ -15,6 +15,9 @@ written permission of Adobe.
 // stdc++
 #include <iostream>
 
+// application
+#include "matchers/utilities.hpp"
+
 /**************************************************************************************************/
 
 namespace hyde {
@@ -255,6 +258,16 @@ bool yaml_function_emitter::emit(const json& jsn, json& out_emitted, const json&
     node["hyde"]["overloads"] = std::move(overloads);
     if (is_ctor) node["hyde"]["is_ctor"] = true;
     if (is_dtor) node["hyde"]["is_dtor"] = true;
+
+    if (_mode == yaml_mode::transcribe && !exists(dst)) {
+        // In this case the symbol name has changed, which has caused a change to the directory name
+        // we are now trying to load and reconcile with what we've created. In this case, we can
+        // assume the "shape" of the documentation is the same, which means that within the parent
+        // folder of `dst` is the actual source folder that holds the old documentation, just under
+        // a different name. Find that folder and rename it.
+
+        std::filesystem::rename(derive_transcription_src_path(dst, node["title"]), dst);
+    }
 
     return reconcile(std::move(node), _dst_root, dst / (filename + ".md"), out_emitted);
 }

--- a/include/output_yaml.hpp
+++ b/include/output_yaml.hpp
@@ -25,8 +25,9 @@ namespace hyde {
 /**************************************************************************************************/
 
 enum class yaml_mode {
-    validate,
-    update,
+    validate,  // ensure the destination docs match the shape of the generated docs
+    update,    // update the destination docs to match the shape of the generated docs
+    transcribe // transcribe the destination docs to match the symbols put out by upgraded tooling
 };
 
 /**************************************************************************************************/

--- a/matchers/utilities.cpp
+++ b/matchers/utilities.cpp
@@ -31,7 +31,11 @@ written permission of Adobe.
 #include "_clang_include_suffix.hpp" // must be last to re-enable warnings
 // clang-format on
 
+// diff
+#include "diff/myers.hpp"
+
 // application
+#include "emitters/yaml_base_emitter_fwd.hpp"
 #include "json.hpp"
 
 using namespace clang;
@@ -982,6 +986,91 @@ const std::string& hyde_version() {
                                       "." + std::to_string(hyde_version_minor_k) +
                                       "." + std::to_string(hyde_version_patch_k);
     return result;
+}
+
+/**************************************************************************************************/
+
+std::filesystem::path derive_transcription_src_path(const std::filesystem::path& dst,
+                                                    const std::string& title) {
+    // std::cout << "deriving transcription src for \"" << title << "\", dst: " << dst.string() << '\n';
+
+    const auto parent = dst.parent_path();
+    std::size_t best_match = std::numeric_limits<std::size_t>::max();
+    std::filesystem::path result;
+    const std::string& current_version = hyde_version();
+
+    for (const auto& entry : std::filesystem::directory_iterator(dst.parent_path())) {
+        const auto sibling = entry.path();
+        if (!is_directory(sibling)) continue;
+        const auto index_path = sibling / index_filename_k;
+
+        if (!exists(index_path)) {
+            std::cerr << "WARN: expected " << index_path.string() << " but did not find one\n";
+            continue;
+        }
+
+        const auto have_docs = parse_documentation(index_path, true);
+
+        if (have_docs._error) {
+            std::cerr << "WARN: expected " << index_path.string() << " to have docs\n";
+            continue;
+        }
+
+        const auto& have = have_docs._json;
+
+        if (have.count("hyde")) {
+            const auto& have_hyde = have.at("hyde");
+            if (have_hyde.count("version")) {
+                // Transcription is when we're going from a previous version of hyde to this one.
+                // So if the versions match, this is a directory that has already been transcribed.
+                // (Transcribing from a newer version of hyde docs to older ones isn't supported.)
+                if (static_cast<const std::string&>(have_hyde.at("version")) == current_version) {
+                    // std::cout << "    candidate (VSKIP) src: " << sibling.string() << '\n';
+                    continue;
+                }
+            }
+        }
+
+        // REVISIT (fosterbrereton): Are these titles editable? Would
+        // users muck with them and thus break this algorithm?
+        const std::string& have_title = static_cast<const std::string&>(have["title"]);
+
+        // score going from what we have to what this version computed.
+        const auto match = diff_score(have_title, title);
+
+        // std::cout << "    candidate (" << match << "): \"" << have_title << "\", src: " << sibling.string() << '\n';
+
+        if (match > best_match) {
+            continue;
+        }
+
+        best_match = match;
+        result = sibling;
+    }
+
+    // std::cout << "    result is: " << result.string() << " (" << best_match << ")\n";
+
+    return result;
+}
+
+/**************************************************************************************************/
+
+std::size_t diff_score(std::string_view src, std::string_view dst) {
+    const myers::patch patch = myers::diff(src, dst);
+    std::size_t score = 0;
+
+    for (const auto& c : patch) {
+        switch (c.operation) {
+            case myers::operation::cpy:
+                break;
+            case myers::operation::del:
+            case myers::operation::ins: {
+                score += c.text.size();
+            } break;
+        }
+    }
+
+    return score;
 }
 
 /**************************************************************************************************/

--- a/matchers/utilities.cpp
+++ b/matchers/utilities.cpp
@@ -351,12 +351,12 @@ inline std::string_view to_string_view(StringRef string) {
 
 /**************************************************************************************************/
 
-inline std::string_view to_string_view(ParamCommandComment::PassDirection x) {
+inline std::string_view to_string_view(ParamCommandPassDirection x) {
     // clang-format off
     switch (x) {
-        case ParamCommandComment::PassDirection::In: return "in";
-        case ParamCommandComment::PassDirection::InOut: return "inout";
-        case ParamCommandComment::PassDirection::Out: return "out";
+        case ParamCommandPassDirection::In: return "in";
+        case ParamCommandPassDirection::InOut: return "inout";
+        case ParamCommandPassDirection::Out: return "out";
     }
     // clang-format on
     return "in"; // gcc on linux is asking for this.
@@ -435,9 +435,9 @@ hyde::optional_json ProcessComment(const ASTContext& n,
     };
 
     switch (comment->getCommentKind()) {
-        case Comment::NoCommentKind:
+        case CommentKind::None:
             break;
-        case Comment::BlockCommandCommentKind: {
+        case CommentKind::BlockCommandComment: {
             const BlockCommandComment* block_command_comment =
                 llvm::dyn_cast_or_null<BlockCommandComment>(comment);
             assert(block_command_comment);
@@ -457,7 +457,7 @@ hyde::optional_json ProcessComment(const ASTContext& n,
             // Do further post-processing if the comment is a hyde command.
             result = post_process_hyde_command(std::move(result));
         } break;
-        case Comment::ParamCommandCommentKind: {
+        case CommentKind::ParamCommandComment: {
             const ParamCommandComment* param_command_comment =
                 llvm::dyn_cast_or_null<ParamCommandComment>(comment);
             assert(param_command_comment);
@@ -477,7 +477,7 @@ hyde::optional_json ProcessComment(const ASTContext& n,
 
             result = roll_up_single_paragraph_child(std::move(result));
         } break;
-        case Comment::TParamCommandCommentKind: {
+        case CommentKind::TParamCommandComment: {
             const TParamCommandComment* tparam_command_comment =
                 llvm::dyn_cast_or_null<TParamCommandComment>(comment);
             assert(tparam_command_comment);
@@ -488,7 +488,7 @@ hyde::optional_json ProcessComment(const ASTContext& n,
 
             result = roll_up_single_paragraph_child(std::move(result));
         } break;
-        case Comment::VerbatimBlockCommentKind: {
+        case CommentKind::VerbatimBlockComment: {
             const VerbatimBlockComment* verbatim_block_comment =
                 llvm::dyn_cast_or_null<VerbatimBlockComment>(comment);
             assert(verbatim_block_comment);
@@ -497,7 +497,7 @@ hyde::optional_json ProcessComment(const ASTContext& n,
                 result["children"] = std::move(*children);
             }
         } break;
-        case Comment::VerbatimLineCommentKind: {
+        case CommentKind::VerbatimLineComment: {
             const VerbatimLineComment* verbatim_line_comment =
                 llvm::dyn_cast_or_null<VerbatimLineComment>(comment);
             assert(verbatim_line_comment);
@@ -506,7 +506,7 @@ hyde::optional_json ProcessComment(const ASTContext& n,
                 result["children"] = std::move(*children);
             }
         } break;
-        case Comment::ParagraphCommentKind: {
+        case CommentKind::ParagraphComment: {
             const ParagraphComment* paragraph_comment =
                 llvm::dyn_cast_or_null<ParagraphComment>(comment);
             assert(paragraph_comment);
@@ -534,7 +534,7 @@ hyde::optional_json ProcessComment(const ASTContext& n,
                 result["text"] = std::move(paragraph);
             }
         } break;
-        case Comment::FullCommentKind: {
+        case CommentKind::FullComment: {
             const FullComment* full_comment_inner = llvm::dyn_cast_or_null<FullComment>(comment);
             assert(full_comment_inner);
 
@@ -542,11 +542,11 @@ hyde::optional_json ProcessComment(const ASTContext& n,
                 result["children"] = std::move(*children);
             }
         } break;
-        case Comment::HTMLEndTagCommentKind:
+        case CommentKind::HTMLEndTagComment:
             break;
-        case Comment::HTMLStartTagCommentKind:
+        case CommentKind::HTMLStartTagComment:
             break;
-        case Comment::InlineCommandCommentKind: {
+        case CommentKind::InlineCommandComment: {
             const InlineCommandComment* inline_command_comment =
                 llvm::dyn_cast_or_null<InlineCommandComment>(comment);
             assert(inline_command_comment);
@@ -557,7 +557,7 @@ hyde::optional_json ProcessComment(const ASTContext& n,
                 result["args"] = std::move(*args);
             }
         } break;
-        case Comment::TextCommentKind: {
+        case CommentKind::TextComment: {
             const TextComment* text_comment = llvm::dyn_cast_or_null<TextComment>(comment);
             assert(text_comment);
 
@@ -567,7 +567,7 @@ hyde::optional_json ProcessComment(const ASTContext& n,
 
             result["text"] = to_string_view(text_comment->getText());
         } break;
-        case Comment::VerbatimBlockLineCommentKind:
+        case CommentKind::VerbatimBlockLineComment:
             break;
     }
 

--- a/matchers/utilities.cpp
+++ b/matchers/utilities.cpp
@@ -973,6 +973,19 @@ hyde::optional_json ProcessComments(const Decl* d) {
 
 /**************************************************************************************************/
 
+constexpr auto hyde_version_major_k = 2;
+constexpr auto hyde_version_minor_k = 1;
+constexpr auto hyde_version_patch_k = 0;
+
+const std::string& hyde_version() {
+    static const std::string result = std::to_string(hyde_version_major_k) +
+                                      "." + std::to_string(hyde_version_minor_k) +
+                                      "." + std::to_string(hyde_version_patch_k);
+    return result;
+}
+
+/**************************************************************************************************/
+
 } // namespace hyde
 
 /**************************************************************************************************/

--- a/matchers/utilities.cpp
+++ b/matchers/utilities.cpp
@@ -351,12 +351,12 @@ inline std::string_view to_string_view(StringRef string) {
 
 /**************************************************************************************************/
 
-inline std::string_view to_string_view(ParamCommandPassDirection x) {
+inline std::string_view to_string_view(ParamCommandComment::PassDirection x) {
     // clang-format off
     switch (x) {
-        case ParamCommandPassDirection::In: return "in";
-        case ParamCommandPassDirection::InOut: return "inout";
-        case ParamCommandPassDirection::Out: return "out";
+        case ParamCommandComment::PassDirection::In: return "in";
+        case ParamCommandComment::PassDirection::InOut: return "inout";
+        case ParamCommandComment::PassDirection::Out: return "out";
     }
     // clang-format on
     return "in"; // gcc on linux is asking for this.
@@ -435,9 +435,9 @@ hyde::optional_json ProcessComment(const ASTContext& n,
     };
 
     switch (comment->getCommentKind()) {
-        case CommentKind::None:
+        case Comment::NoCommentKind:
             break;
-        case CommentKind::BlockCommandComment: {
+        case Comment::BlockCommandCommentKind: {
             const BlockCommandComment* block_command_comment =
                 llvm::dyn_cast_or_null<BlockCommandComment>(comment);
             assert(block_command_comment);
@@ -457,7 +457,7 @@ hyde::optional_json ProcessComment(const ASTContext& n,
             // Do further post-processing if the comment is a hyde command.
             result = post_process_hyde_command(std::move(result));
         } break;
-        case CommentKind::ParamCommandComment: {
+        case Comment::ParamCommandCommentKind: {
             const ParamCommandComment* param_command_comment =
                 llvm::dyn_cast_or_null<ParamCommandComment>(comment);
             assert(param_command_comment);
@@ -477,7 +477,7 @@ hyde::optional_json ProcessComment(const ASTContext& n,
 
             result = roll_up_single_paragraph_child(std::move(result));
         } break;
-        case CommentKind::TParamCommandComment: {
+        case Comment::TParamCommandCommentKind: {
             const TParamCommandComment* tparam_command_comment =
                 llvm::dyn_cast_or_null<TParamCommandComment>(comment);
             assert(tparam_command_comment);
@@ -488,7 +488,7 @@ hyde::optional_json ProcessComment(const ASTContext& n,
 
             result = roll_up_single_paragraph_child(std::move(result));
         } break;
-        case CommentKind::VerbatimBlockComment: {
+        case Comment::VerbatimBlockCommentKind: {
             const VerbatimBlockComment* verbatim_block_comment =
                 llvm::dyn_cast_or_null<VerbatimBlockComment>(comment);
             assert(verbatim_block_comment);
@@ -497,7 +497,7 @@ hyde::optional_json ProcessComment(const ASTContext& n,
                 result["children"] = std::move(*children);
             }
         } break;
-        case CommentKind::VerbatimLineComment: {
+        case Comment::VerbatimLineCommentKind: {
             const VerbatimLineComment* verbatim_line_comment =
                 llvm::dyn_cast_or_null<VerbatimLineComment>(comment);
             assert(verbatim_line_comment);
@@ -506,7 +506,7 @@ hyde::optional_json ProcessComment(const ASTContext& n,
                 result["children"] = std::move(*children);
             }
         } break;
-        case CommentKind::ParagraphComment: {
+        case Comment::ParagraphCommentKind: {
             const ParagraphComment* paragraph_comment =
                 llvm::dyn_cast_or_null<ParagraphComment>(comment);
             assert(paragraph_comment);
@@ -534,7 +534,7 @@ hyde::optional_json ProcessComment(const ASTContext& n,
                 result["text"] = std::move(paragraph);
             }
         } break;
-        case CommentKind::FullComment: {
+        case Comment::FullCommentKind: {
             const FullComment* full_comment_inner = llvm::dyn_cast_or_null<FullComment>(comment);
             assert(full_comment_inner);
 
@@ -542,11 +542,11 @@ hyde::optional_json ProcessComment(const ASTContext& n,
                 result["children"] = std::move(*children);
             }
         } break;
-        case CommentKind::HTMLEndTagComment:
+        case Comment::HTMLEndTagCommentKind:
             break;
-        case CommentKind::HTMLStartTagComment:
+        case Comment::HTMLStartTagCommentKind:
             break;
-        case CommentKind::InlineCommandComment: {
+        case Comment::InlineCommandCommentKind: {
             const InlineCommandComment* inline_command_comment =
                 llvm::dyn_cast_or_null<InlineCommandComment>(comment);
             assert(inline_command_comment);
@@ -557,7 +557,7 @@ hyde::optional_json ProcessComment(const ASTContext& n,
                 result["args"] = std::move(*args);
             }
         } break;
-        case CommentKind::TextComment: {
+        case Comment::TextCommentKind: {
             const TextComment* text_comment = llvm::dyn_cast_or_null<TextComment>(comment);
             assert(text_comment);
 
@@ -567,7 +567,7 @@ hyde::optional_json ProcessComment(const ASTContext& n,
 
             result["text"] = to_string_view(text_comment->getText());
         } break;
-        case CommentKind::VerbatimBlockLineComment:
+        case Comment::VerbatimBlockLineCommentKind:
             break;
     }
 

--- a/matchers/utilities.hpp
+++ b/matchers/utilities.hpp
@@ -11,6 +11,9 @@ written permission of Adobe.
 
 #pragma once
 
+// stdc++
+#include <filesystem>
+
 // clang/llvm
 // clang-format off
 #include "_clang_include_prefix.hpp" // must be first to disable warnings for clang headers
@@ -60,7 +63,20 @@ std::string PostProcessType(const clang::Decl* decl, std::string type);
 // Doxygen-style comments.
 optional_json ProcessComments(const clang::Decl* d);
 
+/**************************************************************************************************/
+
 const std::string& hyde_version();
+
+/**************************************************************************************************/
+
+/// compute a value (based on a diff algorithm) to determine roughly how much two strings are like
+/// each other. The lower the value the better, with 0 meaning the two strings are identical.
+std::size_t diff_score(std::string_view src, std::string_view dst);
+
+// Iterate the list of `dst` subfolders, find their `index.md` files, load the `title` of each, and
+// find the best-fit against the given `title`. This facilitates the transcription behavior.
+std::filesystem::path derive_transcription_src_path(const std::filesystem::path& dst,
+                                                    const std::string& title);
 
 /**************************************************************************************************/
 

--- a/matchers/utilities.hpp
+++ b/matchers/utilities.hpp
@@ -60,6 +60,8 @@ std::string PostProcessType(const clang::Decl* decl, std::string type);
 // Doxygen-style comments.
 optional_json ProcessComments(const clang::Decl* d);
 
+const std::string& hyde_version();
+
 /**************************************************************************************************/
 
 inline std::string to_string(clang::AccessSpecifier access) {

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -43,6 +43,7 @@ written permission of Adobe.
 #include "matchers/namespace_matcher.hpp"
 #include "matchers/typealias_matcher.hpp"
 #include "matchers/typedef_matcher.hpp"
+#include "matchers/utilities.hpp"
 
 using namespace clang::tooling;
 using namespace llvm;
@@ -429,18 +430,6 @@ bool fixup_have_file_subfield(const std::filesystem::path& path) {
 
 /**************************************************************************************************/
 
-constexpr auto hyde_version_major_k = 2;
-constexpr auto hyde_version_minor_k = 0;
-constexpr auto hyde_version_patch_k = 3;
-
-auto hyde_version() {
-    return std::to_string(hyde_version_major_k) +
-           "." + std::to_string(hyde_version_minor_k) +
-           "." + std::to_string(hyde_version_patch_k);
-}
-
-/**************************************************************************************************/
-
 } // namespace
 
 /**************************************************************************************************/
@@ -453,7 +442,7 @@ std::vector<std::string> source_paths(int argc, const char** argv) {
 
 int main(int argc, const char** argv) try {
     llvm::cl::SetVersionPrinter([](llvm::raw_ostream &OS) {
-        OS << "hyde " << hyde_version() << "; llvm " << LLVM_VERSION_STRING << "\n";
+        OS << "hyde " << hyde::hyde_version() << "; llvm " << LLVM_VERSION_STRING << "\n";
     });
 
     command_line_args args = integrate_hyde_config(argc, argv);


### PR DESCRIPTION
It is common during the upgrade from one version of hyde to another that the underlying clang tooling will output different symbol names for a given symbol (e.g., a namespace may get removed or added.) Although the symbol is unchanged, because its `expected` name differs from the `have` name, hyde will consider the symbols different, remove the old name and insert the new one. This wipes out any previous documentation under the old name that should have been migrated to the new name.

The solution here is very specialized. For the "overloads" key only, we gather the name of each overload in both the `have` and `expected` set. We then pair them up according to how well they match to one another (using the Meyers' string diff algorithm; two strings with less "patchwork" between them are considered a better match). Ideally this results in key pairs that represent the same symbol, just with different names. Then we call the `proc` with `have[old_name]` and `expected[new_name]` which will migrate any documentation from the old name to the new.

This capability assumes the overload count of both `have` and `expected` are the same. If any new functions are created or removed between upgrades in the clang driver (e.g., a new compiler-generated routine is created and documented) that will have to be managed manually. Assuming the count is the same, it also assumes there is a 1:1 mapping from the set of old names to the set of new names. This implies the transcription mode should be done as a separate step from an update. In other words, a transcription assumes the documentation is actually the same between the `have` and `expected` sets, it is _just the overload names_ that have changed, so map the old-named documentation to the new-named documentation as reasonably as possible.

This PR also performs a similar technique for class folder names, especially those that may have been mangled or hashed, as changing the symbols will cause those folder names to be different. Using the same Meyers diff, the old folder name that most closely resembles the new folder being created is found and renamed. The reconciliation process then continues as normal.
